### PR TITLE
Two issues fixed

### DIFF
--- a/src/vietj/intellij/asciidoc/editor/AsciiDocPreviewEditorProvider.java
+++ b/src/vietj/intellij/asciidoc/editor/AsciiDocPreviewEditorProvider.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorPolicy;
 import com.intellij.openapi.fileEditor.FileEditorProvider;
 import com.intellij.openapi.fileEditor.FileEditorState;
+import com.intellij.openapi.project.PossiblyDumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jdom.Element;
@@ -28,7 +29,7 @@ import vietj.intellij.asciidoc.AsciiDocLanguage;
 import vietj.intellij.asciidoc.file.AsciiDocFileType;
 
 /** @author Julien Viet */
-public class AsciiDocPreviewEditorProvider implements FileEditorProvider {
+public class AsciiDocPreviewEditorProvider implements FileEditorProvider, PossiblyDumbAware {
 
   /** The id of the editors provided by this {@link FileEditorProvider}. */
   public static final String EDITOR_TYPE_ID = AsciiDocLanguage.LANGUAGE_NAME + "PreviewEditor";
@@ -114,5 +115,14 @@ public class AsciiDocPreviewEditorProvider implements FileEditorProvider {
   @NotNull
   public FileEditorPolicy getPolicy() {
     return FileEditorPolicy.PLACE_AFTER_DEFAULT_EDITOR;
+  }
+
+  /**
+   * Indicates the editor can be created while background indexing is running.
+   *
+   * @return {@code true}
+   */
+  public boolean isDumbAware() {
+    return true;
   }
 }


### PR DESCRIPTION
I fixed two small issues: when reopening the tabs, Asciidoc is now shown again (before, the tabs were not loaded, and you had to reopen the file). Also changed the tab sequence.

Also, when releasing this plugin, don't compile it using JDK 1.7, but use JDK 1.6, otherwise it gives issues on a lot of IntelliJ/other products (there is already an issue for that).
