### PR TITLE
Add preview as you type for split view

### DIFF
--- a/src/main/java/vietj/intellij/asciidoc/AsciiDoc.java
+++ b/src/main/java/vietj/intellij/asciidoc/AsciiDoc.java
@@ -21,15 +21,19 @@ import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 
+import java.io.File;
 import java.util.Map;
 
 /** @author Julien Viet */
 public class AsciiDoc {
-
   /** . */
   private final Asciidoctor asciidoctor;
 
-  public AsciiDoc() {
+  /** Base directory to look up includes. */
+  private final File baseDir;
+
+  public AsciiDoc(File path) {
+    this.baseDir = path;
     ClassLoader old = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(AsciiDocAction.class.getClassLoader());
@@ -55,7 +59,8 @@ public class AsciiDoc {
     Attributes attrs = AttributesBuilder.attributes().showTitle(true)
         .sourceHighlighter("coderay").attribute("coderay-css", "style")
         .attribute("env", "idea").attribute("env-idea").get();
-    OptionsBuilder opts = OptionsBuilder.options().safe(SafeMode.SAFE).backend("html5").headerFooter(false).attributes(attrs);
+    OptionsBuilder opts = OptionsBuilder.options().safe(SafeMode.SAFE).backend("html5").headerFooter(false).attributes(attrs)
+        .baseDir(baseDir);
     return opts.asMap();
   }
 }

--- a/src/main/java/vietj/intellij/asciidoc/AsciiDocAction.java
+++ b/src/main/java/vietj/intellij/asciidoc/AsciiDocAction.java
@@ -21,11 +21,13 @@ import com.intellij.openapi.actionSystem.DataKeys;
 import com.intellij.psi.PsiFile;
 import vietj.intellij.asciidoc.file.AsciiDocFileType;
 
+import java.io.File;
+
 /** @author Julien Viet */
 public class AsciiDocAction extends AnAction {
   public void actionPerformed(AnActionEvent event) {
     PsiFile file = event.getData(DataKeys.PSI_FILE);
-    new AsciiDoc().render(file.getText());
+    new AsciiDoc(new File(file.getOriginalFile().getParent().getVirtualFile().getCanonicalPath())).render(file.getText());
   }
 
   @Override

--- a/src/main/java/vietj/intellij/asciidoc/editor/AsciiDocEditorKit.java
+++ b/src/main/java/vietj/intellij/asciidoc/editor/AsciiDocEditorKit.java
@@ -17,7 +17,10 @@ package vietj.intellij.asciidoc.editor;
 
 import com.intellij.openapi.editor.Document;
 
+import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
+import java.io.File;
+import java.net.MalformedURLException;
 
 /** @author Julien Viet */
 public class AsciiDocEditorKit extends HTMLEditorKit {
@@ -25,7 +28,27 @@ public class AsciiDocEditorKit extends HTMLEditorKit {
   /** The document. */
   private final Document document;
 
-  public AsciiDocEditorKit(Document document) {
+  /** Base directory used to show images. */
+  private File baseDir;
+
+  /**
+   * When the document is created, the base is set to the current file's folder so
+   * that images will displayed in the preview.
+   */
+  @Override
+  public javax.swing.text.Document createDefaultDocument() {
+    HTMLDocument document = (HTMLDocument) super.createDefaultDocument();
+    try {
+      document.setBase(baseDir.toURI().toURL());
+    }
+    catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+    return document;
+  }
+
+  public AsciiDocEditorKit(Document document, File baseDir) {
     this.document = document;
+    this.baseDir = baseDir;
   }
 }


### PR DESCRIPTION
You can now choose "Split Horizontally/Vertically" from the menu and use a preview-as-you-type mode.

Relative images and includes are now also shown in the preview. And it doesn't jump at end of preview on view refresh any more.

Tested locally with IntelliJ IDEA 14 & Java 8. Please have a look & comment or merge.

![preview_splitpane](https://cloud.githubusercontent.com/assets/3957921/5157565/46a80918-7314-11e4-9382-0da9f1d3660e.png)
