### PR TITLE
Rendering exceptions are now shown in event log.

### DIFF
--- a/src/main/java/org/asciidoc/intellij/editor/AsciiDocPreviewEditor.java
+++ b/src/main/java/org/asciidoc/intellij/editor/AsciiDocPreviewEditor.java
@@ -118,11 +118,7 @@ public class AsciiDocPreviewEditor extends UserDataHolderBase implements FileEdi
           }
         } catch (Exception ex) {
           String message = "Error rendering asciidoctor: " + ex.getMessage();
-          if(message.contains("(Encoding::CompatibilityError) incompatible encoding regexp match")) {
-            message += "\nThis message suggests that you are running into a JRuby encoding problem. " +
-                "Try to add '-Dfile.encoding=UTF8' to you VM options";
-          }
-          Notification notification = new Notification("asciidoctor", "Error; " + ex.getMessage(),
+          Notification notification = new Notification("asciidoctor", "Error rendering asciidoctor",
               message, NotificationType.ERROR);
           // increase event log counter
           notification.setImportant(true);


### PR DESCRIPTION
I had some problem with UTF-8 handling on Windows platform. This showed me a problem with the Semaphore handling on exceptions when rendering asciidoctor. 

I added a special hint for encoding problems (probably windows platform only) on how to start the IDE. Adding `-Dfile.encoding=UTF8` to `idea.exe.vmoptions` fixed the problem for me. I hope this will no longer be necessary with a more recent JRuby version due with Asciidoctor 1.5.2
