### PR TITLE
Don't add the asciidoc group to the editor tab popup menu. The action…

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -107,7 +107,6 @@
 
       <separator/>
       <add-to-group group-id="EditorPopupMenu" anchor="first"/>
-      <add-to-group group-id="EditorTabPopupMenu" anchor="first"/>
       <add-to-group group-id="RefactoringMenu" anchor="last"/>
     </group>
   </actions>


### PR DESCRIPTION
…s in the group work with text in the file, not with the file as a whole, so it makes no sense to trigger them through the editor tab.