### PR TITLE
Feature/bugix/87

### DIFF
--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/FormatAsciiDocAction.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/FormatAsciiDocAction.java
@@ -35,38 +35,30 @@ public abstract class FormatAsciiDocAction extends AsciiDocAction {
     final Document document = editor.getDocument();
 
     SelectionModel selectionModel = editor.getSelectionModel();
+    selectText(selectionModel);
+
+    applyMarkup(selectionModel, document, project);
+  }
+
+  protected void selectText(SelectionModel selectionModel) {
     if (!selectionModel.hasSelection()) {
       selectionModel.selectWordAtCaret(false);
     }
-
-    final String newDocumentText = applyMarkup(selectionModel, document);
-    updateDocument(project, document, newDocumentText);
   }
 
-  private String applyMarkup(SelectionModel selectionModel, Document document) {
-    String allText = document.getText();
-
+  private void applyMarkup(SelectionModel selectionModel, Document document, Project project) {
     int start = selectionModel.getSelectionStart();
     int end = selectionModel.getSelectionEnd();
-
-    String startText = allText.substring(0, start);
-    String endText = allText.substring(end, allText.length());
-
     String text = selectionModel.getSelectedText();
-
     final String updatedText = updateSelection(text);
-
-    selectionModel.setSelection(start, end);
-
-    return startText + updatedText + endText;
+    updateDocument(project, document, start, end, updatedText);
   }
 
-
-  private void updateDocument(final Project project, final Document document, final String asciiDoc) {
+  private void updateDocument(final Project project, final Document document, final int start, final int end, final String updatedText) {
     final Runnable readRunner = new Runnable() {
       @Override
       public void run() {
-        document.setText(asciiDoc);
+        document.replaceString(start, end, updatedText);
       }
     };
     ApplicationManager.getApplication().invokeLater(new Runnable() {

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/FormatAsciiDocAction.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/FormatAsciiDocAction.java
@@ -37,7 +37,8 @@ public abstract class FormatAsciiDocAction extends AsciiDocAction {
     SelectionModel selectionModel = editor.getSelectionModel();
     selectText(selectionModel);
 
-    applyMarkup(selectionModel, document, project);
+    String updatedText = updateSelection(selectionModel.getSelectedText());
+    updateDocument(project, document, selectionModel, updatedText);
   }
 
   protected void selectText(SelectionModel selectionModel) {
@@ -46,21 +47,16 @@ public abstract class FormatAsciiDocAction extends AsciiDocAction {
     }
   }
 
-  private void applyMarkup(SelectionModel selectionModel, Document document, Project project) {
-    int start = selectionModel.getSelectionStart();
-    int end = selectionModel.getSelectionEnd();
-    String text = selectionModel.getSelectedText();
-    final String updatedText = updateSelection(text);
-    updateDocument(project, document, start, end, updatedText);
-  }
-
-  private void updateDocument(final Project project, final Document document, final int start, final int end, final String updatedText) {
+  private void updateDocument(final Project project, final Document document, final SelectionModel selectionModel,  final String updatedText) {
     final Runnable readRunner = new Runnable() {
       @Override
       public void run() {
+        int start = selectionModel.getSelectionStart();
+        int end = selectionModel.getSelectionEnd();
         document.replaceString(start, end, updatedText);
       }
     };
+
     ApplicationManager.getApplication().invokeLater(new Runnable() {
       @Override
       public void run() {

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeTitle.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeTitle.java
@@ -1,5 +1,7 @@
 package org.asciidoc.intellij.actions.asciidoc;
 
+import com.intellij.openapi.editor.SelectionModel;
+
 /**
  * @author Erik Pragt
  */
@@ -11,6 +13,17 @@ public class MakeTitle extends FormatAsciiDocAction {
 
   @Override
   public String updateSelection(String selection) {
+
+    if (selection.startsWith("= ")) {
+      return selection.substring(2);
+    }
     return "= " + selection;
   }
+
+  @Override
+  protected void selectText(SelectionModel selectionModel) {
+    selectionModel.selectLineAtCaret();
+    selectionModel.setSelection(selectionModel.getSelectionStart(), selectionModel.getSelectionEnd());
+  }
+
 }

--- a/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeTitleTest.java
+++ b/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeTitleTest.java
@@ -1,0 +1,24 @@
+package org.asciidoc.intellij.actions.asciidoc;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Michael Krausse (ehmkah)
+ * @author Werner Mueller (wemu)
+ */
+public class MakeTitleTest {
+
+  @Test
+  public void testAddTitle() {
+    MakeTitle sut = new MakeTitle();
+    Assert.assertEquals("= hello", sut.updateSelection("hello"));
+  }
+
+  @Test
+  public void testRemoveTitle() {
+    MakeTitle sut = new MakeTitle();
+    Assert.assertEquals("hello", sut.updateSelection("= hello"));
+  }
+
+}


### PR DESCRIPTION
This should be a bugfix for https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/87 

We changed:
- selection for title is always complete line (because a title can not start in the middle of a line)
- updating the complete document is done with an IntelliJ Method (replace)
- method selectText allows to change what is selected (e.g. Title always selects line, other actions have not been changed)
- a unit-test show the behaviour of the changed MakeTitle class

Greetings from wemu and ehmkah from hackgergarten Bern (http://www.meetup.com/de/Hackergarten-Bern) We would be happy if you would accept it :-)