### PR TITLE
Fix `getName()` of `MakeMono` class

### DIFF
--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeMono.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeMono.java
@@ -16,7 +16,7 @@ public class MakeMono extends FormatAsciiDocAction {
 
   @Override
   public String getName() {
-    return "MakeItalic";
+    return "MakeMono";
   }
 
 


### PR DESCRIPTION
The method returned a wrong string. This commit fixes this and makes it
consistent.