### PR TITLE
Add Title to Create Table Dialog

### DIFF
--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/CreateTableAction.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/CreateTableAction.java
@@ -9,7 +9,6 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
-import org.asciidoc.intellij.actions.asciidoc.AsciiDocAction;
 import org.asciidoc.intellij.ui.CreateTableDialog;
 import org.jetbrains.annotations.NotNull;
 
@@ -41,9 +40,9 @@ public class CreateTableAction extends AsciiDocAction {
             public void run() {
               document.insertString(offset,
                   generateTable(
-                      createTableDialog.getNrOfColumns(),
-                      createTableDialog.getNrofRows(),
-                      createTableDialog.useTitle()));
+                      createTableDialog.getColumnCount(),
+                      createTableDialog.getRowCount(),
+                      createTableDialog.getTitle()));
             }
           });
         }
@@ -53,12 +52,12 @@ public class CreateTableAction extends AsciiDocAction {
  }
 
 
-  private String generateTable(int cols, int rows, boolean withTitle) {
+  private String generateTable(int cols, int rows, String title) {
     assert cols > 0;
     assert rows > 0;
     StringBuilder table = new StringBuilder("\n");
-    if (withTitle) {
-      table.append(".Table title\n");
+    if (!title.isEmpty()) {
+      table.append(".").append(title).append("\n");
     }
     table.append("|===\n");
     // Create header columns

--- a/src/main/java/org/asciidoc/intellij/ui/CreateTableDialog.java
+++ b/src/main/java/org/asciidoc/intellij/ui/CreateTableDialog.java
@@ -7,10 +7,10 @@ import javax.swing.*;
 import java.awt.*;
 
 public class CreateTableDialog extends DialogWrapper {
-  private SpinnerNumberModel smCols = new SpinnerNumberModel(3 ,1, 99, 1);
-  private SpinnerNumberModel smRows = new SpinnerNumberModel(3 ,1, 99, 1);
+  private SpinnerNumberModel columnCount = new SpinnerNumberModel(3, 1, 99, 1);
+  private SpinnerNumberModel rowCount = new SpinnerNumberModel(3, 1, 99, 1);
 
-  private JCheckBox title;
+  private JTextField title = new JTextField("", 5);
 
   public CreateTableDialog() {
     super(false);
@@ -24,35 +24,36 @@ public class CreateTableDialog extends DialogWrapper {
   protected JComponent createCenterPanel() {
     JPanel panel = new JPanel(new GridLayout(3, 0));
 
-    JPanel useTitle = new JPanel(new BorderLayout());
-    title = new JCheckBox("Use title", true);
-    useTitle.add(title, BorderLayout.CENTER);
-    panel.add(useTitle);
+    JPanel addTitle = new JPanel(new BorderLayout());
+    addTitle.add(new JLabel("Title"), BorderLayout.LINE_START);
+    addTitle.add(new JPanel(), BorderLayout.CENTER); //Spacing between label and text field
+    addTitle.add(title, BorderLayout.LINE_END);
+    panel.add(addTitle);
 
     JPanel columns = new JPanel(new BorderLayout());
-    columns.add(new JLabel("Nr. of rows"), BorderLayout.CENTER);
-    JSpinner rows = new JSpinner(smRows);
+    columns.add(new JLabel("No of rows"), BorderLayout.CENTER);
+    JSpinner rows = new JSpinner(this.rowCount);
     columns.add(rows, BorderLayout.LINE_END);
     panel.add(columns);
 
     JPanel rowPane = new JPanel(new BorderLayout());
-    rowPane.add(new JLabel("Nr. of colums"), BorderLayout.CENTER);
-    JSpinner cols = new JSpinner(smCols);
+    rowPane.add(new JLabel("No of colums"), BorderLayout.CENTER);
+    JSpinner cols = new JSpinner(this.columnCount);
     rowPane.add(cols, BorderLayout.LINE_END);
     panel.add(rowPane);
 
     return panel;
   }
 
-  public int getNrofRows() {
-    return smRows.getNumber().intValue();
+  public int getRowCount() {
+    return rowCount.getNumber().intValue();
   }
 
-  public int getNrOfColumns() {
-    return smCols.getNumber().intValue();
+  public int getColumnCount() {
+    return columnCount.getNumber().intValue();
   }
 
-  public boolean useTitle() {
-    return title.isSelected();
+  public String getTitle() {
+    return title.getText();
   }
 }


### PR DESCRIPTION
This commit changes the `CreateTableDialog`, so that it allows to type
the title of the table directly. This replaces the checkbox 'use title'
that was used before. Leaving the input empty is equal to not ticking
the checkbox.