### PR TITLE
ehmkah: feature whenever there occurs a TODO string in an asciidoc (n…

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -122,5 +122,6 @@
     <lang.psiStructureViewFactory language="AsciiDoc" implementationClass="org.asciidoc.intellij.structureView.AsciiDocStructureViewFactory"/>
     <spellchecker.support language="AsciiDoc" implementationClass="org.asciidoc.intellij.AsciiDocSpellcheckingStrategy"/>
     <lang.commenter language="AsciiDoc" implementationClass="org.asciidoc.intellij.AsciiDocCommenter"/>
+    <todoIndexer filetype="AsciiDoc" implementationClass="org.asciidoc.intellij.indexer.AsciiDocTodoIndexer"/>
   </extensions>
 </idea-plugin>

--- a/src/main/java/org/asciidoc/intellij/indexer/AsciiDocFilterLexer.java
+++ b/src/main/java/org/asciidoc/intellij/indexer/AsciiDocFilterLexer.java
@@ -1,0 +1,24 @@
+package org.asciidoc.intellij.indexer;
+
+import com.intellij.lexer.EmptyLexer;
+import com.intellij.psi.impl.cache.impl.BaseFilterLexer;
+import com.intellij.psi.impl.cache.impl.OccurrenceConsumer;
+import com.intellij.psi.search.UsageSearchContext;
+
+/**
+ * @author Michael Krausse (ehmkah)
+ */
+public class AsciiDocFilterLexer extends BaseFilterLexer  {
+
+  public AsciiDocFilterLexer(EmptyLexer emptyLexer, OccurrenceConsumer consumer) {
+    super(emptyLexer, consumer);
+  }
+
+  @Override
+  public void advance() {
+    scanWordsInToken(UsageSearchContext.IN_PLAIN_TEXT, false, false);
+    advanceTodoItemCountsInToken();
+    myDelegate.advance();
+  }
+
+}

--- a/src/main/java/org/asciidoc/intellij/indexer/AsciiDocIdIndexer.java
+++ b/src/main/java/org/asciidoc/intellij/indexer/AsciiDocIdIndexer.java
@@ -1,0 +1,21 @@
+package org.asciidoc.intellij.indexer;
+
+import com.intellij.lexer.EmptyLexer;
+import com.intellij.lexer.Lexer;
+import com.intellij.psi.impl.cache.impl.OccurrenceConsumer;
+import com.intellij.psi.impl.cache.impl.id.LexerBasedIdIndexer;
+
+/**
+ * @author Michael Krausse (ehmkah)
+ */
+public class AsciiDocIdIndexer extends LexerBasedIdIndexer {
+
+  public static Lexer createIndexingLexer(OccurrenceConsumer consumer) {
+    return new AsciiDocFilterLexer(new EmptyLexer(), consumer);
+  }
+
+  @Override
+  public Lexer createLexer(final OccurrenceConsumer consumer) {
+    return createIndexingLexer(consumer);
+  }
+}

--- a/src/main/java/org/asciidoc/intellij/indexer/AsciiDocTodoIndexer.java
+++ b/src/main/java/org/asciidoc/intellij/indexer/AsciiDocTodoIndexer.java
@@ -1,0 +1,18 @@
+package org.asciidoc.intellij.indexer;
+
+import com.intellij.lexer.Lexer;
+import com.intellij.psi.impl.cache.impl.OccurrenceConsumer;
+import com.intellij.psi.impl.cache.impl.todo.LexerBasedTodoIndexer;
+
+/**
+ *
+ * @author Michael Krausse (ehmkah)
+ */
+public class AsciiDocTodoIndexer extends LexerBasedTodoIndexer {
+
+
+  @Override
+  public Lexer createLexer(OccurrenceConsumer consumer) {
+    return AsciiDocIdIndexer.createIndexingLexer(consumer);
+  }
+}


### PR DESCRIPTION
Hi @bodiam A possible solution for counting the TODO ins Asciidoctor files. It works exactly the same like the Markdown plugin. So number of found TODOs does not depend on whether the occure in a comment or not.

Maybe you could check whether the package ````org.asciidoc.intellij.indexer```` fits for, but I am willing to move it to better place if you name it. 

No unit tests this time, because I do not know what to test. 