### PR TITLE
use constrained quotes when possible

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -42,7 +42,7 @@
       </profile-state>
     </entry>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA IU-162.1121.32" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" assert-keyword="true" jdk-15="true" project-jdk-name="IntelliJ IDEA IU-162.1121.32" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeBold.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeBold.java
@@ -6,8 +6,8 @@ package org.asciidoc.intellij.actions.asciidoc;
 public class MakeBold extends SimpleFormatAsciiDocAction {
 
   @Override
-  public String updateSelection(String selection) {
-    return updateSelectionIntern(selection, "*");
+  public String updateSelection(String selection, boolean isWord) {
+    return updateSelectionIntern(selection, "*", isWord);
   }
 
   @Override

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeItalic.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeItalic.java
@@ -6,8 +6,8 @@ package org.asciidoc.intellij.actions.asciidoc;
 public class MakeItalic extends SimpleFormatAsciiDocAction {
 
   @Override
-  public String updateSelection(String selection) {
-    return updateSelectionIntern(selection, "_");
+  public String updateSelection(String selection, boolean isWord) {
+    return updateSelectionIntern(selection, "_", isWord);
   }
 
   @Override

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeLink.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeLink.java
@@ -13,7 +13,7 @@ public class MakeLink extends FormatAsciiDocAction {
   }
 
   @Override
-  public String updateSelection(String selection) {
+  public String updateSelection(String selection, boolean isWord) {
     if (isLink(selection)) {
       return selection + "[]";
     }

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeMono.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeMono.java
@@ -6,8 +6,8 @@ package org.asciidoc.intellij.actions.asciidoc;
 public class MakeMono extends SimpleFormatAsciiDocAction {
 
   @Override
-  public String updateSelection(String selection) {
-    return updateSelectionIntern(selection, "`");
+  public String updateSelection(String selection, boolean isWord) {
+    return updateSelectionIntern(selection, "`", isWord);
   }
 
   @Override

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeStrikethrough.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeStrikethrough.java
@@ -10,11 +10,19 @@ public class MakeStrikethrough extends FormatAsciiDocAction {
   }
 
   @Override
-  public String updateSelection(String selection) {
+  public String updateSelection(String selection, boolean isWord) {
+    if(selection.startsWith("[line-through]##") && selection.endsWith("##")) {
+      return selection.substring(16, selection.length() - 2);
+    }
+
     if(selection.startsWith("[line-through]#") && selection.endsWith("#")) {
       return selection.substring(15, selection.length() - 1);
     }
 
-    return "[line-through]#" + selection + "#";
+    String symbol = "#";
+    if(!isWord) {
+      symbol += symbol;
+    }
+    return "[line-through]" + symbol + selection + symbol;
   }
 }

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeTitle.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/MakeTitle.java
@@ -12,7 +12,7 @@ public class MakeTitle extends FormatAsciiDocAction {
   }
 
   @Override
-  public String updateSelection(String selection) {
+  public String updateSelection(String selection, boolean isWord) {
 
     if (selection.startsWith("= ")) {
       return selection.substring(2);

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/SimpleFormatAsciiDocAction.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/SimpleFormatAsciiDocAction.java
@@ -5,20 +5,23 @@ package org.asciidoc.intellij.actions.asciidoc;
  */
 public abstract class SimpleFormatAsciiDocAction extends FormatAsciiDocAction {
 
-  protected String updateSelectionIntern(String selection, String symbol) {
+  protected String updateSelectionIntern(String selection, String symbol, boolean isWord) {
     if (containsSymbol(selection, symbol)) {
       return removeSymbol(selection, symbol);
     }
-    return appendSymbol(selection, symbol);
+    return appendSymbol(selection, symbol, isWord);
   }
 
-  private String appendSymbol(String selection, String symbol) {
-    String doubleSymbol = symbol + symbol;
-    return doubleSymbol + selection + doubleSymbol;
+  private String appendSymbol(String selection, String symbol, boolean isWord) {
+    String matchingSymbol = symbol;
+    if(!isWord) {
+      matchingSymbol += symbol;
+    }
+    return matchingSymbol + selection + matchingSymbol;
   }
 
   private String removeSymbol(String selection, String symbol) {
-    if (selection.startsWith(symbol + symbol)) {
+    if (selection.startsWith(symbol + symbol) && selection.endsWith(symbol + symbol)) {
       return removeSymbol(selection, 2);
     }
     return removeSymbol(selection, 1);

--- a/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeBoldTest.java
+++ b/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeBoldTest.java
@@ -13,37 +13,50 @@ public class MakeBoldTest {
 
   @Test
   public void shouldAddAsteriks() throws Exception {
-    String actual = sut.updateSelection("about");
+    String actual = sut.updateSelection("about", false);
     assertEquals("**about**", actual);
   }
 
   @Test
   public void shouldRemoveSingleAsteriks() throws Exception {
-    String actual = sut.updateSelection("*about*");
+    String actual = sut.updateSelection("*about*", false);
     assertEquals("about", actual);
   }
 
   @Test
   public void shouldRemoveTwoAsteriks() throws Exception {
-    String actual = sut.updateSelection("**about**");
+    String actual = sut.updateSelection("**about**", false);
     assertEquals("about", actual);
   }
 
   @Test
   public void shouldAddAsteriksBecauseSelectionOnlyStartsWithAsteriks() throws Exception {
-    String actual = sut.updateSelection("*about");
+    String actual = sut.updateSelection("*about", false);
     assertEquals("***about**", actual);
   }
 
   @Test
   public void shouldNotCrashWithTwoAsteriks() throws Exception {
-    String actual = sut.updateSelection("**");
+    String actual = sut.updateSelection("**", false);
     assertEquals("", actual);
   }
 
   @Test
   public void shouldNotCrashWithOneAsteriks() throws Exception {
-    String actual = sut.updateSelection("*");
+    String actual = sut.updateSelection("*", false);
     assertEquals("", actual);
   }
+
+  @Test
+  public void shouldAddSingleAsteriskWhenIsWord() throws Exception {
+    String actual = sut.updateSelection("about", true);
+    assertEquals("*about*", actual);
+  }
+
+  @Test
+  public void shouldRemoveOneWhitespaceWhenUbalanced() throws Exception {
+    String actual = sut.updateSelection("**about*", true);
+    assertEquals("*about", actual);
+  }
+
 }

--- a/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeLinkTest.java
+++ b/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeLinkTest.java
@@ -45,11 +45,11 @@ public class MakeLinkTest {
 
   @Test
   public void testUpdateSelection1() throws Exception {
-    assertEquals("http://example.com[]", sut.updateSelection("http://example.com"));
+    assertEquals("http://example.com[]", sut.updateSelection("http://example.com", false));
   }
 
   @Test
   public void testUpdateSelection2() throws Exception {
-    assertEquals("http://www.example.com[www.example.com]", sut.updateSelection("www.example.com"));
+    assertEquals("http://www.example.com[www.example.com]", sut.updateSelection("www.example.com", false));
   }
 }

--- a/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeTitleTest.java
+++ b/src/test/java/org/asciidoc/intellij/actions/asciidoc/MakeTitleTest.java
@@ -12,13 +12,13 @@ public class MakeTitleTest {
   @Test
   public void testAddTitle() {
     MakeTitle sut = new MakeTitle();
-    Assert.assertEquals("= hello", sut.updateSelection("hello"));
+    Assert.assertEquals("= hello", sut.updateSelection("hello", false));
   }
 
   @Test
   public void testRemoveTitle() {
     MakeTitle sut = new MakeTitle();
-    Assert.assertEquals("hello", sut.updateSelection("= hello"));
+    Assert.assertEquals("hello", sut.updateSelection("= hello", false));
   }
 
 }


### PR DESCRIPTION
This tries to fix issue #123. 

The new method FormatAsciiDocAction#isWord() tries to capture Asciidoc's "unconstrained quotes" logic. 

I'm relying on Java 8 `\p{IsAlphabetic}` to identify Unicode characters. 

Comments welcome. I could upload a preview release next week once I am connected to a fast internet again. 

@bodiam, @mojavelinux - please let me know if this looks like what was intended.