### PR TITLE
autoscrolling JavaFX preview and links opening in a new browser window

### DIFF
--- a/src/main/java/org/asciidoc/intellij/AsciiDoc.java
+++ b/src/main/java/org/asciidoc/intellij/AsciiDoc.java
@@ -23,6 +23,7 @@ import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Map;
 
 /** @author Julien Viet */
@@ -39,6 +40,12 @@ public class AsciiDoc {
     try {
       Thread.currentThread().setContextClassLoader(AsciiDocAction.class.getClassLoader());
       asciidoctor = Asciidoctor.Factory.create();
+      asciidoctor.requireLibrary("asciidoctor-diagram");
+      InputStream is = this.getClass().getResourceAsStream("/sourceline-treeprocessor.rb");
+      if(is == null) {
+        throw new RuntimeException("unable to load script sourceline-treeprocessor.rb");
+      }
+      asciidoctor.rubyExtensionRegistry().loadClass(is).treeprocessor("SourceLineTreeProcessor");
     }
     finally {
       Thread.currentThread().setContextClassLoader(old);
@@ -49,7 +56,6 @@ public class AsciiDoc {
     ClassLoader old = Thread.currentThread().getContextClassLoader();
     try {
       Thread.currentThread().setContextClassLoader(AsciiDocAction.class.getClassLoader());
-      asciidoctor.requireLibrary("asciidoctor-diagram");
       return "<div id=\"content\">\n" + asciidoctor.render(text, getDefaultOptions()) + "\n</div>";
     }
     finally {
@@ -61,7 +67,7 @@ public class AsciiDoc {
     Attributes attrs = AttributesBuilder.attributes().showTitle(true)
         .sourceHighlighter("coderay").attribute("coderay-css", "style")
         .attribute("env", "idea").attribute("env-idea").get();
-    OptionsBuilder opts = OptionsBuilder.options().safe(SafeMode.UNSAFE).backend("html5").headerFooter(false).attributes(attrs)
+    OptionsBuilder opts = OptionsBuilder.options().safe(SafeMode.UNSAFE).backend("html5").headerFooter(false).attributes(attrs).option("sourcemap", "true")
         .baseDir(baseDir);
     return opts.asMap();
   }

--- a/src/main/java/org/asciidoc/intellij/MayLineTreeProcessor.java
+++ b/src/main/java/org/asciidoc/intellij/MayLineTreeProcessor.java
@@ -1,0 +1,24 @@
+package org.asciidoc.intellij;
+
+import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.Document;
+import org.asciidoctor.extension.Treeprocessor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Alexander Schwartz (msg systems ag) 2016
+ */
+public class MayLineTreeProcessor extends Treeprocessor {
+  @Override
+  public Document process(Document document) {
+    Map map = new HashMap();
+    List<AbstractBlock> items = document.findBy(map);
+    for(AbstractBlock block : items) {
+      block.setAttr("role", "data-line-", true);
+    }
+    return document;
+  }
+}

--- a/src/main/java/org/asciidoc/intellij/editor/AsciiDocHtmlPanel.java
+++ b/src/main/java/org/asciidoc/intellij/editor/AsciiDocHtmlPanel.java
@@ -23,4 +23,6 @@ public abstract class AsciiDocHtmlPanel implements Disposable {
     }
     return result.toString();
   }
+
+  public abstract void scrollToLine(int line, int lineCount);
 }

--- a/src/main/java/org/asciidoc/intellij/editor/AsciiDocPreviewEditor.java
+++ b/src/main/java/org/asciidoc/intellij/editor/AsciiDocPreviewEditor.java
@@ -65,6 +65,10 @@ public class AsciiDocPreviewEditor extends UserDataHolderBase implements FileEdi
   /** Indicates whether the HTML preview is obsolete and should regenerated from the AsciiDoc {@link #document}. */
   private transient String currentContent = "";
 
+  private transient int targetLineNo = 0;
+
+  private transient int currentLineNo = 0;
+
   /** The {@link Document} previewed in this editor. */
   protected final Document document;
 
@@ -96,6 +100,10 @@ public class AsciiDocPreviewEditor extends UserDataHolderBase implements FileEdi
             if (markup != null) {
               myPanel.setHtml(markup);
             }
+          }
+          if (currentLineNo != targetLineNo) {
+            currentLineNo = targetLineNo;
+            myPanel.scrollToLine(targetLineNo, document.getLineCount());
           }
         }
         catch (InterruptedException e) {
@@ -339,6 +347,11 @@ public class AsciiDocPreviewEditor extends UserDataHolderBase implements FileEdi
   /** Dispose the editor. */
   public void dispose() {
     Disposer.dispose(this);
+  }
+
+  public void scrollToLine(int line) {
+    targetLineNo = line;
+    renderIfVisible();
   }
 
   private class MyUpdatePanelOnSettingsChangedListener implements AsciiDocApplicationSettings.SettingsChangedListener {

--- a/src/main/java/org/asciidoc/intellij/editor/AsciiDocSplitEditor.java
+++ b/src/main/java/org/asciidoc/intellij/editor/AsciiDocSplitEditor.java
@@ -59,9 +59,7 @@ public class AsciiDocSplitEditor extends SplitFileEditor<TextEditor, AsciiDocPre
         return;
       }
 
-      final int offset = editor.logicalPositionToOffset(e.getNewPosition());
-      // TODO
-      // myPreviewFileEditor.scrollToSrcOffset(offset);
+      myPreviewFileEditor.scrollToLine(e.getNewPosition().line);
     }
   }
 }

--- a/src/main/java/org/asciidoc/intellij/editor/jeditor/JeditorHtmlPanel.java
+++ b/src/main/java/org/asciidoc/intellij/editor/jeditor/JeditorHtmlPanel.java
@@ -111,6 +111,11 @@ final class JeditorHtmlPanel extends AsciiDocHtmlPanel {
     setHtml(myLastRenderedHtml);
   }
 
+  @Override
+  public void scrollToLine(int line, int lineCount) {
+    // NOOP
+  }
+
   private void adjustBrowserSize() {
   }
 

--- a/src/main/resources/org/asciidoc/intellij/editor/javafx/processLinks.js
+++ b/src/main/resources/org/asciidoc/intellij/editor/javafx/processLinks.js
@@ -1,0 +1,42 @@
+if (window.__IntelliJTools === undefined) {
+  window.__IntelliJTools = {}
+}
+
+(function() {
+  var openInExternalBrowser = function(href) {
+    window.JavaPanelBridge.openInExternalBrowser(href);
+  }
+
+  window.__IntelliJTools.processClick = function() {
+    if (!this.href) {
+      return false;
+    }
+
+    if (this.href[0] == '#') {
+      var elementId = this.href.substring(1)
+      var elementById = document.getElementById(elementId);
+      if (elementById) {
+        elementById.scrollIntoView();
+      }
+    }
+    else {
+      openInExternalBrowser(this.href);
+    }
+
+    return false;
+  }
+
+  window.onload = function() {
+    setTimeout(function () {
+      var links = document.getElementsByTagName("a");
+      //window.JavaPanelBridge.log(links.length)
+      for (var i = 0; i < links.length; ++i) {
+        var link = links[i];
+
+        link.onclick = __IntelliJTools.processClick
+        //window.JavaPanelBridge.log(link + ' ' + link.onclick)
+      }
+    }, 100)
+  }
+
+})()

--- a/src/main/resources/org/asciidoc/intellij/editor/javafx/scrollToElement.js
+++ b/src/main/resources/org/asciidoc/intellij/editor/javafx/scrollToElement.js
@@ -1,0 +1,90 @@
+if (window.__IntelliJTools === undefined) {
+  window.__IntelliJTools = {}
+}
+
+window.__IntelliJTools.scrollToLine = (function () {
+
+  var oldLineToScroll = 0;
+
+  var getLine = function (node) {
+    if (!node || !('className' in node)) {
+      return null
+    }
+    var classes = node.className.split(' ');
+
+    for (var i = 0; i < classes.length; i++) {
+      var className = classes[i]
+      if (className.match(/^data-line-stdin-/)) {
+        return className.substr("data-line-stdin-".length);
+      }
+    }
+
+    return null
+  }
+
+  var scrollToLine = function (newLineToScroll, lineCount) {
+
+    // the sourcelines will be as CSS class on div elements only
+    var blocks = document.getElementsByTagName('div');
+    var startY;
+    var startLine;
+    var endY;
+    var endLine = lineCount;
+
+    for (var i = 0; i < blocks.length; i++) {
+      var block = blocks[i]
+      var lineOfBlock = getLine(block);
+      if (lineOfBlock <= newLineToScroll) {
+        startY = block.offsetTop
+        startLine = lineOfBlock
+        // there might be no further block, therefore assume that the end is at the end of this block
+        endY = block.offsetTop + block.offsetHeight
+      }
+      else if (lineOfBlock > newLineToScroll) {
+        endY = block.offsetTop
+        endLine = lineOfBlock
+        break
+      }
+    }
+
+    var resultY = startY
+
+    // interpolate the relative position inside the current block
+    if (endY !== undefined && newLineToScroll != startLine) {
+      resultY += (newLineToScroll - startLine) / (endLine - startLine) * (endY - startY)
+    }
+
+    var height = window.innerHeight
+    var relativeWindowPosition = 0.5;
+    var oldValue = document.documentElement.scrollTop || document.body.scrollTop;
+
+    // ensure that the assumed position is between x% of the window height depending on scroll direction
+    if (oldLineToScroll < newLineToScroll) {
+      relativeWindowPosition = 0.8
+    }
+    else if (oldLineToScroll > newLineToScroll) {
+      relativeWindowPosition = 0.1
+    }
+    // if we catch the cursor (i.e. due to edit after scrolling), we'll place it at x% of the window hight
+    else if (resultY < oldValue || resultY > oldValue + window.height) {
+      relativeWindowPosition = 0.3
+    }
+
+    if (oldLineToScroll != newLineToScroll) {
+      var newValue = resultY - height * relativeWindowPosition;
+
+      // ensure consistent scrolling when scrolling up or down
+      if ((oldLineToScroll < newLineToScroll && oldValue < newValue) ||
+          (oldLineToScroll > newLineToScroll && oldValue > newValue) ||
+          (resultY < oldValue || resultY > oldValue + window.height)) {
+        document.documentElement.scrollTop = document.body.scrollTop = newValue;
+      }
+
+      oldLineToScroll = newLineToScroll;
+    }
+
+  }
+
+  return scrollToLine
+})()
+

--- a/src/main/resources/sourceline-treeprocessor.rb
+++ b/src/main/resources/sourceline-treeprocessor.rb
@@ -1,0 +1,20 @@
+
+require 'asciidoctor/extensions'
+
+include ::Asciidoctor
+
+class SourceLineTreeProcessor < Extensions::Treeprocessor
+  def process document
+
+    document.find_by.each do |node|
+
+      # on each node add the source file information as role (will result in CSS class in HTML)
+      if (node.source_location) then
+        node.attributes['role'] = 'data-line-' + (node.source_location.file || 'stdin') + "-#{node.source_location.lineno}"
+      end
+    end
+    nil
+  end
+
+
+end


### PR DESCRIPTION
This PR borrows ideas from Markdown plugin to open links in new browser windows and scroll the preview to the current cursor position. Both features load some extra JavaScript into the preview. 

Closing #130. Closing #121. 

Adding source code lines to the HTML is done using a (Ruby) TreeProcessor (like it is done in AsciidocFX editor). 

There is a limitation to this: The source line is in the HTML output only once per DIV. That means only once per text block. A long list that will span multiple items is still one block. Therefore the scrolling is a bit bumpy. 

I'm wondering if this is good enough, or if more source line information can be added to the HTML, or if I could use some interpolation algorithm, or something completely different.