### PR TITLE
adding darcula CSS theme for JavaFX

### DIFF
--- a/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxHtmlPanel.java
+++ b/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxHtmlPanel.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.NotNullLazyValue;
 import com.intellij.ui.JBColor;
+import com.intellij.util.ui.UIUtil;
 import com.sun.javafx.application.PlatformImpl;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -91,6 +92,9 @@ public class JavaFxHtmlPanel extends AsciiDocHtmlPanel {
 
     try {
       myInlineCss = IOUtils.toString(JavaFxHtmlPanel.class.getResourceAsStream("default.css"));
+      if(UIUtil.isUnderDarcula()) {
+        myInlineCss += IOUtils.toString(JavaFxHtmlPanel.class.getResourceAsStream("darcula.css"));
+      }
     }
     catch (IOException e) {
       String message = "Error rendering asciidoctor: " + e.getMessage();
@@ -111,7 +115,7 @@ public class JavaFxHtmlPanel extends AsciiDocHtmlPanel {
 
             updateFontSmoothingType(myWebView, false);
             myWebView.setContextMenuEnabled(false);
-            myWebView.getEngine().loadContent("<html><head></head><body>Initializing...</body>");
+            myWebView.getEngine().loadContent(prepareHtml("<html><head></head><body>Initializing...</body>"));
 
             final WebEngine engine = myWebView.getEngine();
             engine.getLoadWorker().stateProperty().addListener(myBridgeSettingListener);

--- a/src/main/java/org/asciidoc/intellij/editor/javafx/darcula.css
+++ b/src/main/java/org/asciidoc/intellij/editor/javafx/darcula.css
@@ -1,0 +1,24 @@
+#content>h1:first-child:not([class]), body {background-color: #45494a;color: #bbbbbb}
+pre, pre>code, *:not(pre)>code, .hljs {background-color: #626262;color: #bbbbbb}
+a, a:hover, a:focus { color: #589df6; }
+
+table.tableblock, th.tableblock, td.tableblock{color: #bbbbbb}
+
+blockquote, cite {color: #bbbbbb !important;}
+
+/* was: f8f8f7 */
+table tbody tr{background:#45494a}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#626262}
+
+/* was f7f8f7 */
+table thead,table tfoot{background:#626262}
+tbody tr th{background:#626262}
+
+/* was: 7a2518 */
+.sidebarblock>.content>.title,#toctitle,.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{color: #ba3925}
+
+/* was: f7f7f8 */
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#626262}
+
+#toc {background-color:#626262 !important; border-color:#626262 !important;}


### PR DESCRIPTION
This is a preview for darcula support, intended to close #122.

@bodiam - do you want to give it a try? A preview is available here: https://github.com/ahus1/asciidoctor-intellij-plugin/releases/tag/0.16.0.3

I've implemented a darcula.css that overrides the default CSS classes to make them "dark". I hope I've caught the most important ones. 

If I've missed some classes, please post a small asciidoc snipped showing what is not working yet.