### PR TITLE
create temp image dir and set outdir to this dir (JavaFX Panel only)

### DIFF
--- a/src/main/java/org/asciidoc/intellij/actions/AsciiDocAction.java
+++ b/src/main/java/org/asciidoc/intellij/actions/AsciiDocAction.java
@@ -29,7 +29,7 @@ public class AsciiDocAction extends AnAction {
 
   public void actionPerformed(AnActionEvent event) {
     PsiFile file = event.getData(LangDataKeys.PSI_FILE);
-    new AsciiDoc(new File(file.getOriginalFile().getParent().getVirtualFile().getCanonicalPath())).render(file.getText());
+    new AsciiDoc(new File(file.getOriginalFile().getParent().getVirtualFile().getCanonicalPath()), null).render(file.getText());
   }
 
   @Override

--- a/src/main/java/org/asciidoc/intellij/editor/AsciiDocHtmlPanelProvider.java
+++ b/src/main/java/org/asciidoc/intellij/editor/AsciiDocHtmlPanelProvider.java
@@ -9,6 +9,7 @@ import com.intellij.util.xmlb.annotations.Attribute;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.nio.file.Path;
 
 public abstract class AsciiDocHtmlPanelProvider {
 
@@ -18,7 +19,7 @@ public abstract class AsciiDocHtmlPanelProvider {
   private static AsciiDocHtmlPanelProvider[] ourProviders = null;
 
   @NotNull
-  public abstract AsciiDocHtmlPanel createHtmlPanel(Document document);
+  public abstract AsciiDocHtmlPanel createHtmlPanel(Document document, Path imagesPath);
 
   @NotNull
   public abstract AvailabilityInfo isAvailable();

--- a/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxHtmlPanel.java
+++ b/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxHtmlPanel.java
@@ -37,6 +37,9 @@ import java.awt.*;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -84,9 +87,15 @@ public class JavaFxHtmlPanel extends AsciiDocHtmlPanel {
 
   private int lineCount = 0;
 
-  public JavaFxHtmlPanel(Document document) {
+  private final Path imagesPath;
+
+  public JavaFxHtmlPanel(Document document, Path imagesPath) {
+
     //System.setProperty("prism.lcdtext", "false");
     //System.setProperty("prism.text", "t2k");
+
+    this.imagesPath = imagesPath;
+
     myPanelWrapper = new JPanel(new BorderLayout());
     myPanelWrapper.setBackground(JBColor.background());
 
@@ -209,6 +218,16 @@ public class JavaFxHtmlPanel extends AsciiDocHtmlPanel {
     });
   }
 
+  private String findTempImageFile(String _fileName) {
+    if (imagesPath != null) {
+      Path file = imagesPath.resolve(_fileName);
+      if (Files.exists(file)) {
+        return Paths.get(base).relativize(file).toString();
+      }
+    }
+    return _fileName;
+  }
+
   private String prepareHtml(@NotNull String html) {
     /* for each image we'll calculate a MD5 sum of its content. Once the content changes, MD5 and therefore the URL
     * will change. The changed URL is necessary for the JavaFX web view to display the new content, as each URL
@@ -218,6 +237,7 @@ public class JavaFxHtmlPanel extends AsciiDocHtmlPanel {
     while (matcher.find()) {
       final MatchResult matchResult = matcher.toMatchResult();
       String file = matchResult.group(1);
+      file = findTempImageFile(file);
       String md5 = calculateMd5(file);
       String replacement = "<img src=\"localfile://" + md5 + "/" + base + "/" + file + "\"";
       html = html.substring(0, matchResult.start()) +

--- a/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxHtmlPanelProvider.java
+++ b/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxHtmlPanelProvider.java
@@ -6,6 +6,7 @@ import org.asciidoc.intellij.editor.AsciiDocHtmlPanelProvider;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.URL;
+import java.nio.file.Path;
 
 public class JavaFxHtmlPanelProvider extends AsciiDocHtmlPanelProvider {
 
@@ -15,8 +16,8 @@ public class JavaFxHtmlPanelProvider extends AsciiDocHtmlPanelProvider {
 
   @NotNull
   @Override
-  public AsciiDocHtmlPanel createHtmlPanel(Document document) {
-    return new JavaFxHtmlPanel(document);
+  public AsciiDocHtmlPanel createHtmlPanel(Document document, Path imagesPath) {
+    return new JavaFxHtmlPanel(document, imagesPath);
   }
 
   @NotNull

--- a/src/main/java/org/asciidoc/intellij/editor/jeditor/JeditorHtmlPanelProvider.java
+++ b/src/main/java/org/asciidoc/intellij/editor/jeditor/JeditorHtmlPanelProvider.java
@@ -5,12 +5,14 @@ import org.asciidoc.intellij.editor.AsciiDocHtmlPanel;
 import org.asciidoc.intellij.editor.AsciiDocHtmlPanelProvider;
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.file.Path;
+
 public final class JeditorHtmlPanelProvider extends AsciiDocHtmlPanelProvider {
   public static final ProviderInfo INFO = new ProviderInfo("Swing", JeditorHtmlPanelProvider.class.getName());
 
   @NotNull
   @Override
-  public AsciiDocHtmlPanel createHtmlPanel(Document document) {
+  public AsciiDocHtmlPanel createHtmlPanel(Document document, Path imagesPath) {
     return new JeditorHtmlPanel(document);
   }
 


### PR DESCRIPTION
I implemented this feature as discussed in https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/162

I only tested it on OSX!
There might be an issue under windows (colons) (JavaFxHtmlPanel, line 225:  return Paths.get(base).relativize(file).toString();). 
I set the outdir attribute so that the .asciidoctor directory gets created in the temp directory as well

The temp dir gets created whenever an editor is opened, so switching between Swing and JavaFX is possible.

I couldn't figure out when the AsciiDocAction is used. I pass null as the imagesPath parameter in actionPerformed...
