### PR TITLE
Configure attribute entries in settings panel

### DIFF
--- a/src/main/java/org/asciidoc/intellij/AsciiDoc.java
+++ b/src/main/java/org/asciidoc/intellij/AsciiDoc.java
@@ -15,9 +15,18 @@
  */
 package org.asciidoc.intellij;
 
+import java.io.File;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.logging.Logger;
+
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.geronimo.gshell.io.SystemOutputHijacker;
 import org.asciidoc.intellij.actions.AsciiDocAction;
 import org.asciidoc.intellij.editor.AsciiDocPreviewEditor;
@@ -29,14 +38,6 @@ import org.asciidoctor.AttributesBuilder;
 import org.asciidoctor.OptionsBuilder;
 import org.asciidoctor.SafeMode;
 import org.asciidoctor.log.LogHandler;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.InputStream;
-import java.io.PrintStream;
-import java.nio.file.Path;
-import java.util.Map;
-import java.util.logging.Logger;
 
 /**
  * @author Julien Viet
@@ -88,7 +89,7 @@ public class AsciiDoc {
           }
           asciidoctor.rubyExtensionRegistry().loadClass(is);
         } finally {
-          if(asciidoctor != null) {
+          if (asciidoctor != null) {
             asciidoctor.unregisterLogHandler(logHandler);
           }
           SystemOutputHijacker.deregister();
@@ -141,14 +142,22 @@ public class AsciiDoc {
       .sourceHighlighter("coderay").attribute("coderay-css", "style")
       .attribute("env", "idea").attribute("env-idea").get();
 
+    final AsciiDocApplicationSettings settings = AsciiDocApplicationSettings.getInstance();
     if (imagesPath != null) {
-      final AsciiDocApplicationSettings settings = AsciiDocApplicationSettings.getInstance();
       if (settings.getAsciiDocPreviewSettings().getHtmlPanelProviderInfo().getClassName().equals(JavaFxHtmlPanelProvider.class.getName())) {
         attrs.setAttribute("outdir", imagesPath.toAbsolutePath().normalize().toString());
       }
     }
-    OptionsBuilder opts = OptionsBuilder.options().safe(SafeMode.UNSAFE).backend("html5").headerFooter(false).attributes(attrs).option("sourcemap", "true")
+
+    Attributes settingsAttributes = AttributesBuilder.attributes()
+      .attributes(Collections.unmodifiableMap(settings.getAsciiDocPreviewSettings().getAttributes())).get();
+
+    OptionsBuilder opts = OptionsBuilder.options().safe(SafeMode.UNSAFE).backend("html5").headerFooter(false)
+      .attributes(attrs)
+      .attributes(settingsAttributes)
+      .option("sourcemap", "true")
       .baseDir(baseDir);
+
     return opts.asMap();
   }
 }

--- a/src/main/java/org/asciidoc/intellij/editor/AsciiDocPreviewEditor.java
+++ b/src/main/java/org/asciidoc/intellij/editor/AsciiDocPreviewEditor.java
@@ -150,7 +150,8 @@ public class AsciiDocPreviewEditor extends UserDataHolderBase implements FileEdi
 
     if (provider.isAvailable() != AsciiDocHtmlPanelProvider.AvailabilityInfo.AVAILABLE) {
       settings.setAsciiDocPreviewSettings(new AsciiDocPreviewSettings(settings.getAsciiDocPreviewSettings().getSplitEditorLayout(),
-          AsciiDocPreviewSettings.DEFAULT.getHtmlPanelProviderInfo(), settings.getAsciiDocPreviewSettings().getPreviewTheme()));
+        AsciiDocPreviewSettings.DEFAULT.getHtmlPanelProviderInfo(), settings.getAsciiDocPreviewSettings().getPreviewTheme(),
+        settings.getAsciiDocPreviewSettings().getAttributes()));
 
       /* the following will not work, IntellIJ will show the error "parent must be showing" when this is
          tiggered during startup. */

--- a/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxCouldBeEnabledNotificationProvider.java
+++ b/src/main/java/org/asciidoc/intellij/editor/javafx/JavaFxCouldBeEnabledNotificationProvider.java
@@ -53,13 +53,13 @@ public class JavaFxCouldBeEnabledNotificationProvider extends EditorNotification
         final boolean isSuccess = availabilityInfo.checkAvailability(panel);
         if (isSuccess) {
           asciiDocApplicationSettings.setAsciiDocPreviewSettings(new AsciiDocPreviewSettings(
-              oldPreviewSettings.getSplitEditorLayout(),
-              new JavaFxHtmlPanelProvider().getProviderInfo(),
-              oldPreviewSettings.getPreviewTheme()
+            oldPreviewSettings.getSplitEditorLayout(),
+            new JavaFxHtmlPanelProvider().getProviderInfo(),
+            oldPreviewSettings.getPreviewTheme(),
+            oldPreviewSettings.getAttributes()
           ));
           EditorNotifications.updateAll();
-        }
-        else {
+        } else {
           Logger.getInstance(JavaFxCouldBeEnabledNotificationProvider.class).warn("Could not install and apply OpenJFX");
         }
       }

--- a/src/main/java/org/asciidoc/intellij/settings/AsciiDocPreviewSettings.java
+++ b/src/main/java/org/asciidoc/intellij/settings/AsciiDocPreviewSettings.java
@@ -1,8 +1,14 @@
 package org.asciidoc.intellij.settings;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.intellij.util.xmlb.annotations.Attribute;
+import com.intellij.util.xmlb.annotations.MapAnnotation;
 import com.intellij.util.xmlb.annotations.Property;
 import com.intellij.util.xmlb.annotations.Tag;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.asciidoc.intellij.editor.AsciiDocHtmlPanel;
 import org.asciidoc.intellij.editor.AsciiDocHtmlPanelProvider;
 import org.asciidoc.intellij.editor.javafx.JavaFxHtmlPanelProvider;
@@ -33,15 +39,22 @@ public final class AsciiDocPreviewSettings {
   @NotNull
   private AsciiDocHtmlPanel.PreviewTheme myPreviewTheme = AsciiDocHtmlPanel.PreviewTheme.INTELLIJ;
 
+  @Property(surroundWithTag = false)
+  @MapAnnotation(surroundWithTag = false, entryTagName = "attribute")
+  @NotNull
+  private Map<String, String> attributes = new HashMap<>();
+
   public AsciiDocPreviewSettings() {
   }
 
   public AsciiDocPreviewSettings(@NotNull SplitFileEditor.SplitEditorLayout splitEditorLayout,
                                  @NotNull AsciiDocHtmlPanelProvider.ProviderInfo htmlPanelProviderInfo,
-                                 @NotNull AsciiDocHtmlPanel.PreviewTheme previewTheme) {
+                                 @NotNull AsciiDocHtmlPanel.PreviewTheme previewTheme,
+                                 @NotNull Map<String, String> attributes) {
     mySplitEditorLayout = splitEditorLayout;
     myHtmlPanelProviderInfo = htmlPanelProviderInfo;
     myPreviewTheme = previewTheme;
+    this.attributes = attributes;
   }
 
   @NotNull
@@ -65,18 +78,22 @@ public final class AsciiDocPreviewSettings {
     return myHtmlPanelProviderInfo;
   }
 
+  @NotNull
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
 
-    AsciiDocPreviewSettings settings = (AsciiDocPreviewSettings)o;
+    AsciiDocPreviewSettings that = (AsciiDocPreviewSettings) o;
 
-    if (mySplitEditorLayout != settings.mySplitEditorLayout) return false;
-    if (myPreviewTheme != settings.myPreviewTheme) return false;
-    if (!myHtmlPanelProviderInfo.equals(settings.myHtmlPanelProviderInfo)) return false;
-
-    return true;
+    if (mySplitEditorLayout != that.mySplitEditorLayout) return false;
+    if (!myHtmlPanelProviderInfo.equals(that.myHtmlPanelProviderInfo)) return false;
+    if (myPreviewTheme != that.myPreviewTheme) return false;
+    return attributes.equals(that.attributes);
   }
 
   @Override
@@ -84,6 +101,7 @@ public final class AsciiDocPreviewSettings {
     int result = mySplitEditorLayout.hashCode();
     result = 31 * result + myHtmlPanelProviderInfo.hashCode();
     result = 31 * result + myPreviewTheme.hashCode();
+    result = 31 * result + attributes.hashCode();
     return result;
   }
 

--- a/src/main/java/org/asciidoc/intellij/settings/AsciiDocPreviewSettingsForm.form
+++ b/src/main/java/org/asciidoc/intellij/settings/AsciiDocPreviewSettingsForm.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.asciidoc.intellij.settings.AsciiDocPreviewSettingsForm">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="188" height="400"/>
+      <xy x="20" y="20" width="243" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -16,7 +16,7 @@
       </component>
       <vspacer id="685ea">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="3" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="d284a" class="com.intellij.ui.components.JBLabel">
@@ -61,6 +61,27 @@
         </constraints>
         <properties/>
       </component>
+      <component id="8ac70" class="com.intellij.ui.components.JBLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <horizontalAlignment value="10"/>
+          <text value="Attributes:"/>
+        </properties>
+      </component>
+      <grid id="1d4b0" binding="attributesPanel" custom-create="true" layout-manager="BorderLayout" hgap="0" vgap="0">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="9" fill="0" indent="0" use-parent-layout="false">
+            <maximum-size width="-1" height="200"/>
+          </grid>
+        </constraints>
+        <properties/>
+        <border type="none">
+          <size top="0" left="0" bottom="5" right="0"/>
+        </border>
+        <children/>
+      </grid>
     </children>
   </grid>
 </form>

--- a/src/main/java/org/asciidoc/intellij/settings/AttributeTable.java
+++ b/src/main/java/org/asciidoc/intellij/settings/AttributeTable.java
@@ -1,0 +1,73 @@
+package org.asciidoc.intellij.settings;
+
+import com.intellij.execution.util.ListTableWithButtons;
+import com.intellij.util.ui.ColumnInfo;
+import com.intellij.util.ui.ListTableModel;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * @author Julian Ronge 2018
+ */
+public class AttributeTable extends ListTableWithButtons<AttributeTableItem> {
+
+  private static final ColumnInfo<AttributeTableItem, String> NAME_COLUMN = new ColumnInfo<AttributeTableItem, String>("Key") {
+    @Nullable
+    @Override
+    public String valueOf(AttributeTableItem item) {
+      return item.getKey();
+    }
+
+    @Override
+    public boolean isCellEditable(AttributeTableItem item) {
+      return true;
+    }
+
+    @Override
+    public void setValue(AttributeTableItem item, String value) {
+      item.setKey(value);
+    }
+  };
+
+  private static final ColumnInfo<AttributeTableItem, String> SCOPE_COLUMN = new ColumnInfo<AttributeTableItem, String>("Value") {
+    @Nullable
+    @Override
+    public String valueOf(AttributeTableItem item) {
+      return item.getValue();
+    }
+
+    @Override
+    public boolean isCellEditable(AttributeTableItem item) {
+      return true;
+    }
+
+    @Override
+    public void setValue(AttributeTableItem item, String value) {
+      item.setValue(value);
+    }
+  };
+
+  @Override
+  protected ListTableModel createListModel() {
+    return new ListTableModel<AttributeTableItem>(NAME_COLUMN, SCOPE_COLUMN);
+  }
+
+  @Override
+  protected AttributeTableItem createElement() {
+    return new AttributeTableItem();
+  }
+
+  @Override
+  protected boolean isEmpty(AttributeTableItem element) {
+    return element.getKey() == null;
+  }
+
+  @Override
+  protected AttributeTableItem cloneElement(AttributeTableItem attributeTableItem) {
+    return new AttributeTableItem(attributeTableItem.getKey(), attributeTableItem.getValue());
+  }
+
+  @Override
+  protected boolean canDeleteElement(AttributeTableItem selection) {
+    return true;
+  }
+}

--- a/src/main/java/org/asciidoc/intellij/settings/AttributeTableItem.java
+++ b/src/main/java/org/asciidoc/intellij/settings/AttributeTableItem.java
@@ -1,0 +1,34 @@
+package org.asciidoc.intellij.settings;
+
+/**
+ * @author Julian Ronge 2018
+ */
+public class AttributeTableItem {
+  private String key;
+  private String value;
+
+  public AttributeTableItem(String key, String value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public AttributeTableItem() {
+
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/src/test/java/org/asciidoc/intellij/AsciiDocTest.java
+++ b/src/test/java/org/asciidoc/intellij/AsciiDocTest.java
@@ -1,25 +1,25 @@
 package org.asciidoc.intellij;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
 import java.io.File;
+
+import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase;
+import org.asciidoc.intellij.settings.AsciiDocApplicationSettings;
+import org.junit.Assert;
 
 /**
  * @author Alexander Schwartz 2018
  */
-public class AsciiDocTest {
+public class AsciiDocTest extends LightPlatformCodeInsightFixtureTestCase {
 
   private AsciiDoc asciidoc;
 
-  @Before
-  public void setup() {
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
     asciidoc = new AsciiDoc(new File("."), null, "test");
   }
 
-  @Test
-  public void shouldRenderPlantUmlAsPng() {
+  public void testShouldRenderPlantUmlAsPng() {
     String html = asciidoc.render("[plantuml,test,format=svg]\n" +
       "----\n" +
       "List <|.. ArrayList\n" +
@@ -27,10 +27,16 @@ public class AsciiDocTest {
     Assert.assertTrue(html.contains("src=\"test.png\""));
   }
 
-  @Test
-  public void shouldRenderPlainAsciidoc() {
+  public void testShouldRenderPlainAsciidoc() {
     String html = asciidoc.render("this is *bold*.");
     System.out.println(html);
     Assert.assertTrue(html.contains("<strong>bold</strong>"));
+  }
+
+  public void testShouldRenderAttributesAsciidoc() {
+    String expectedContent = "should replace attribute placeholder with value";
+    AsciiDocApplicationSettings.getInstance().getAsciiDocPreviewSettings().getAttributes().put("attr", expectedContent);
+    String html = asciidoc.render("{attr}");
+    Assert.assertTrue(html.contains(expectedContent));
   }
 }


### PR DESCRIPTION
Hello!
I added the possibility to configure attribute entries in the settings panel. We needed this feature because we set attributes in our maven builds for include paths and some other attributes depending on the environment which of course did not work in the preview.

Now we can configure the asciidoc attributes in the plugin:

![screenshot](https://user-images.githubusercontent.com/1029939/45673718-bd606880-bb2b-11e8-8c35-fa80d88c78ca.PNG)
