### PR TITLE
Bump asciidoctor-diagram version to 2.0.5

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ This document provides a high-level view of the changes introduced by release.
 === 0.31.34 (work in progress)
 
 - dialog to paste an image allows adding the width for the image (thanks to @martingreilinger) (#412, #559)
+- upgrade to asciidoctorj-diagram 2.0.5
 
 === 0.31.33 (preview, available from GitHub releases)
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ dependencies {
   implementation 'org.apache.commons:commons-text:1.8'
 
   // when updating the versions here, also update them in AsciiDocDownloaderUtil for dynamic download
-  testImplementation 'org.asciidoctor:asciidoctorj-diagram:2.0.2'
+  testImplementation 'org.asciidoctor:asciidoctorj-diagram:2.0.5'
   testImplementation 'org.asciidoctor:asciidoctorj-pdf:1.5.3'
 
   testImplementation 'junit:junit:4.12'

--- a/src/main/java/org/asciidoc/intellij/download/AsciiDocDownloaderUtil.java
+++ b/src/main/java/org/asciidoc/intellij/download/AsciiDocDownloaderUtil.java
@@ -49,7 +49,7 @@ public class AsciiDocDownloaderUtil {
   public static final String ASCIIDOCTORJ_PDF_VERSION = "1.5.3";
   private static final String ASCIIDOCTORJ_PDF_HASH = "ccaccbef0af5b5e836ff983f5ed682ff3e063851";
 
-  public static final String ASCIIDOCTORJ_DIAGRAM_VERSION = "2.0.2";
+  public static final String ASCIIDOCTORJ_DIAGRAM_VERSION = "2.0.5";
   private static final String ASCIIDOCTORJ_DIAGRAM_HASH = "f0b7b9bcecc20a7aeece8733996d3fe75eb7ed5b";
 
   private static final String DOWNLOAD_CACHE_DIRECTORY = "download-cache";


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [x] No

If yes, please describe the breaking change:

The answer to the question above is 'maybe'. This shouldn't be a breaking change, but Robert Panzer and I did some work on the image ouput directory selection mechanism which may have an influence on the preview view. Safe made in particular might be something to check.