### PR TITLE
Improving readability & reducing internal knowledge in tests

### DIFF
--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/ImageMacroAttributeService.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/ImageMacroAttributeService.java
@@ -3,6 +3,7 @@ package org.asciidoc.intellij.actions.asciidoc;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.components.ServiceManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 @Service
 public final class ImageMacroAttributeService {
@@ -12,8 +13,15 @@ public final class ImageMacroAttributeService {
 
   private final MacroAttributeService macroAttributeService;
 
+  // is created by ServiceManager
+  @SuppressWarnings("unused")
   public ImageMacroAttributeService() {
     macroAttributeService = ServiceManager.getService(MacroAttributeService.class);
+  }
+
+  @TestOnly
+  public ImageMacroAttributeService(MacroAttributeService macroAttributeService) {
+    this.macroAttributeService = macroAttributeService;
   }
 
   public @NotNull String toAttributeString(@NotNull final ImageAttributes attributes) {

--- a/src/test/java/org/asciidoc/intellij/actions/asciidoc/ImageMacroAttributeServiceTest.java
+++ b/src/test/java/org/asciidoc/intellij/actions/asciidoc/ImageMacroAttributeServiceTest.java
@@ -1,75 +1,38 @@
 package org.asciidoc.intellij.actions.asciidoc;
 
-import com.intellij.openapi.components.ServiceManager;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(MockitoJUnitRunner.class)
 public class ImageMacroAttributeServiceTest {
-
-  @Mock
-  private ImageAttributes imageAttributes;
-
-  @Mock
-  private MacroAttributeService macroAttributeService;
-
-  @Mock
-  private MacroAttribute attributeWithLabel;
-
-  @Mock
-  private MacroAttribute attributeInQuotesWithLabel;
-
-  private MockedStatic<ServiceManager> mockedServiceManager;
-  private MockedStatic<MacroAttribute> mockedMacroAttribute;
 
   private ImageMacroAttributeService service;
 
   @Before
   public void setup() {
-    mockedServiceManager = Mockito.mockStatic(ServiceManager.class);
-    mockedMacroAttribute = Mockito.mockStatic(MacroAttribute.class);
-
-    mockedServiceManager.when(() -> ServiceManager.getService(MacroAttributeService.class))
-      .thenReturn(macroAttributeService);
-
-    service = new ImageMacroAttributeService();
-  }
-
-  @After
-  public void teardown() {
-    mockedServiceManager.close();
-    mockedMacroAttribute.close();
+    service = new ImageMacroAttributeService(new MacroAttributeService());
   }
 
   @Test
   public void shouldPassMacroAttributesCorrectlyToTheAttributeService() {
-    final Optional<Integer> widthOption = Optional.of(250);
-    final Optional<String> altOption = Optional.of("Image description");
-    final String attributeString = "attributeString";
-    when(macroAttributeService.toAttributeString(any())).thenReturn(attributeString);
-    when(imageAttributes.getWidth()).thenReturn(widthOption);
-    when(imageAttributes.getAlt()).thenReturn(altOption);
-    mockedMacroAttribute.when(() -> MacroAttribute.createWithLabel(widthOption, "width"))
-      .thenReturn(attributeWithLabel);
-    mockedMacroAttribute.when(() -> MacroAttribute.createInQuotesWithLabel(altOption, "alt"))
-      .thenReturn(attributeInQuotesWithLabel);
+    ImageAttributes imageAttributes = new ImageAttributes() {
+
+      @Override
+      public Optional<Integer> getWidth() {
+        return Optional.of(250);
+      }
+
+      @Override
+      public Optional<String> getAlt() {
+        return Optional.of("Image description");
+      }
+    };
 
     final String result = service.toAttributeString(imageAttributes);
 
-    assertEquals(result, attributeString);
-    verify(macroAttributeService).toAttributeString(attributeWithLabel, attributeInQuotesWithLabel);
+    assertThat(result).isEqualTo("width=250,alt=\"Image description\"");
   }
 }

--- a/src/test/java/org/asciidoc/intellij/actions/asciidoc/MacroAttributeServiceTest.java
+++ b/src/test/java/org/asciidoc/intellij/actions/asciidoc/MacroAttributeServiceTest.java
@@ -1,16 +1,11 @@
 package org.asciidoc.intellij.actions.asciidoc;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class MacroAttributeServiceTest {
 
@@ -23,9 +18,9 @@ public class MacroAttributeServiceTest {
 
   @Test
   public void shouldMapMacroAttributesToLabelString() {
-    final MacroAttribute attribute1 = mockedMacroAttribute(Optional.of("source"));
-    final MacroAttribute attribute2 = mockedMacroAttribute(Optional.of("java"));
-    final MacroAttribute attribute3 = mockedMacroAttribute(Optional.of("title=\"Example 1\""));
+    final MacroAttribute attribute1 = new MacroAttribute(Optional.of("source"), Optional.empty(), false);
+    final MacroAttribute attribute2 = new MacroAttribute(Optional.of("java"), Optional.empty(), false);
+    final MacroAttribute attribute3 = new MacroAttribute(Optional.of("Example 1"), Optional.of("title"), true);
 
     final String attributes = service.toAttributeString(attribute1, attribute2, attribute3);
 
@@ -34,13 +29,12 @@ public class MacroAttributeServiceTest {
 
   @Test
   public void shouldFilterEmptyMacroAttributes() {
-    final MacroAttribute attribute = mockedMacroAttribute(Optional.of("alt=\"Some alt text\""));
-    final MacroAttribute empty = mockedMacroAttribute(Optional.empty());
+    final MacroAttribute attribute = new MacroAttribute(Optional.of("Some alt text"), Optional.of("alt"), true);
+    final MacroAttribute empty = new MacroAttribute(Optional.empty(), Optional.empty(), false);
 
     final String attributes = service.toAttributeString(attribute, empty);
 
     assertEquals("alt=\"Some alt text\"", attributes);
-    verify(empty, never()).asAttributeStringOption();
   }
 
   @Test
@@ -48,12 +42,4 @@ public class MacroAttributeServiceTest {
     assertEquals("", service.toAttributeString());
   }
 
-  private @NotNull MacroAttribute mockedMacroAttribute(final @NotNull Optional<String> stringValueOption) {
-    final MacroAttribute attribute = mock(MacroAttribute.class);
-
-    when(attribute.hasValue()).thenReturn(stringValueOption.isPresent());
-    when(attribute.asAttributeStringOption()).thenReturn(stringValueOption);
-
-    return attribute;
-  }
 }


### PR DESCRIPTION
removing verify() from from tests as it depends on the internal implementation.
Use existing lightweight objects to instead of Mockito to improve readability.

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other, please describe: refactoring

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No


