### PR TITLE
fix #564: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,25 @@
-<!-- PULL REQUEST TEMPLATE -->
-<!-- (Update "[ ]" to "[x]" to check a box) -->
-
-**What kind of change does this PR introduce?** (check at least one)
-
+## What kind of change does this PR introduce?
+<!-- Place an `x` in all the boxes that apply -->
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Documentation
 - [ ] Other, please describe:
 
-**Does this PR introduce a breaking change?** (check one)
-
-- [ ] Yes
+## Does this PR introduce a breaking change?** (check one)
+<!-- Place an `x` in one of the boxes -->
 - [ ] No
+- [ ] Yes
 
-If yes, please describe the breaking change:
+<!-- If yes, please describe the breaking change below -->
 
-**Please try to ensure:**
+## Checklist:
+<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
+<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] I have read the [**CONTRIBUTING**](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/CONTRIBUTING.adoc) document.
+- [ ] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx`, where `xxx` is the issue number.
+- [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and [existing](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) tests passed.
 
-- When resolving a specific issue, reference it in the PR's title (e.g. `fix #xxx`, where "xxx" is the issue number)
-
-If you're adding or changing functionality:
-- Existing tests should pass: https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html
-- Try to add new or update tests. Maintainers will help new contributors.
-
-If adding a **new feature**:
-- Update the feature documentation: https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/doc/users-guide/modules/ROOT/pages/features/
-
-**Other information:**
+<!-- Please add any additional remarks below -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 - [ ] Documentation
 - [ ] Other, please describe:
 
-## Does this PR introduce a breaking change?** (check one)
+## Does this PR introduce a breaking change?
 <!-- Place an `x` in one of the boxes -->
 - [ ] No
 - [ ] Yes
@@ -16,7 +16,7 @@
 <!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I have read the [**CONTRIBUTING**](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/CONTRIBUTING.adoc) document.
-- [ ] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx`, where `xxx` is the issue number.
+- [ ] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx` (where `xxx` is the issue number).
 - [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and [existing](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) tests passed.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other, please describe:

Change in the PR template. As requested (#564), it leaves less open ends, encourages the contributors to go over and confirm the guidelines, and hides some of the previously visible instructions. I'll probably use something similar myself. :)

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

Some portions are loosely based [TalAter's](https://github.com/TalAter/open-source-templates) template.