### PR TITLE
Use upper case in numbered list

### DIFF
--- a/doc/contributors-guide/modules/ROOT/pages/coder/upgrading-asciidoctor.adoc
+++ b/doc/contributors-guide/modules/ROOT/pages/coder/upgrading-asciidoctor.adoc
@@ -2,7 +2,7 @@
 
 Follow these steps:
 
-. update `build.gradle` with the latest available AsciidoctorJ release
+. Update `build.gradle` with the latest available AsciidoctorJ release
 
 The preview of `JavaFxHtmlPanel` and `AsciiDocJCEFHtmlPanel` and will automatically load the most recent style sheets and patch them accordingly at runtime.
 

--- a/doc/contributors-guide/modules/ROOT/pages/coder/upgrading-asciidoctor.adoc
+++ b/doc/contributors-guide/modules/ROOT/pages/coder/upgrading-asciidoctor.adoc
@@ -4,5 +4,5 @@ Follow these steps:
 
 . Update `build.gradle` with the latest available AsciidoctorJ release
 
-The preview of `JavaFxHtmlPanel` and `AsciiDocJCEFHtmlPanel` and will automatically load the most recent style sheets and patch them accordingly at runtime.
+The previews of `JavaFxHtmlPanel` and `AsciiDocJCEFHtmlPanel` will automatically load the most recent style sheets and patch them accordingly at runtime.
 


### PR DESCRIPTION
I was checking the docs and I found 2 improvements in `upgrading-asciidoctor.adoc`
1. DONE: Use upper case in the numbered lost, same as in the other documents in the docs.
2. NEED CONFIRMATION: the sentence at the bottom did not feel right, I applied some minimal changes. Let me know if these are right.

## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

<!-- If yes, please describe the breaking change below -->

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/CONTRIBUTING.adoc) document.
- [x] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx` (where `xxx` is the issue number).
*I hope so* :crossed_fingers:
- [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/master/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.
*N/A*
- [ ] I have added tests to cover my changes.
*N/A*
- [ ] I need help writing a test to cover my change (Maintainers are willing to help).
*N/A*
- [x] All new and [existing](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) tests passed.

<!-- Please add any additional remarks below -->

