### PR TITLE
fix typos in language bundle for passthrough content

### DIFF
--- a/src/main/resources/AsciiDocBundle.properties
+++ b/src/main/resources/AsciiDocBundle.properties
@@ -38,8 +38,8 @@ asciidoc.settings.enable.asciiDocErrorsInEditor=Show AsciiDoc errors and warning
 asciidoc.settings.enable.inplacePreviewRefresh=Replace preview contents without flicker (JavaFX and JCEF preview only)
 
 asciidoc.settings.enable.injections=Enable automatic language injection in source blocks
-asciidoc.settings.default.injections.passthrough=Language for pass trough content:
-asciidoc.settings.default.injections.passthrough.hint=Clear field to disable injection for pass through content
+asciidoc.settings.default.injections.passthrough=Language for passthrough content:
+asciidoc.settings.default.injections.passthrough.hint=Clear field to disable injection for passthrough content
 asciidoc.settings.disable.injections.languages=Disable automatic language for:
 asciidoc.settings.disable.injections.hint1=Use ; to separate language names
 asciidoc.settings.disable.injections.hint2=Language injection will be disabled automatically when there is an include::[] in the block


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other: language bundle update

## Does this PR introduce a breaking change?

- [x] No
- [ ] Yes

The correct terminology is "passthrough content" as defined by the AsciiDoc language documentation (see https://github.com/asciidoctor/asciidoc-docs/blob/main/modules/subs/pages/prevent.adoc#passthroughs). I added a missing "h" in through and removed the space between "pass" and "through".

