### PR TITLE
Fix #601 A space between line comment marker and the following text

### DIFF
--- a/src/main/java/org/asciidoc/intellij/pasteProvider/AsciiDocPasteProvider.java
+++ b/src/main/java/org/asciidoc/intellij/pasteProvider/AsciiDocPasteProvider.java
@@ -68,7 +68,7 @@ public class AsciiDocPasteProvider implements PasteProvider {
     if (produce.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
       java.util.List<File> fileList;
       try {
-        //noinspection unchecked
+        // noinspection unchecked
         fileList = (List<File>) produce.getTransferData(DataFlavor.javaFileListFlavor);
       } catch (UnsupportedFlavorException | IOException e) {
         return false;

--- a/src/main/java/org/asciidoc/intellij/psi/AsciiDocSectionImpl.java
+++ b/src/main/java/org/asciidoc/intellij/psi/AsciiDocSectionImpl.java
@@ -150,7 +150,7 @@ public class AsciiDocSectionImpl extends AsciiDocSectionStubElementImpl<AsciiDoc
     if (keyToCompare.length() == ownKey.length()) {
       return true;
     }
-    //noinspection RedundantIfStatement
+    // noinspection RedundantIfStatement
     if (keyToCompare.substring(ownKey.length()).matches("^_[0-9]*$")) {
       return true;
     }

--- a/src/main/java/org/asciidoc/intellij/settings/AsciiDocPreviewSettingsForm.java
+++ b/src/main/java/org/asciidoc/intellij/settings/AsciiDocPreviewSettingsForm.java
@@ -86,7 +86,7 @@ public class AsciiDocPreviewSettingsForm implements AsciiDocPreviewSettings.Hold
   }
 
   private void createUIComponents() {
-    //noinspection unchecked
+    // noinspection unchecked
     final List<AsciiDocHtmlPanelProvider.ProviderInfo> providerInfos =
       ContainerUtil.mapNotNull(AsciiDocHtmlPanelProvider.getProviders(),
         provider -> {

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocAnchorWithoutIdInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocAnchorWithoutIdInspectionTest.java
@@ -12,7 +12,7 @@ public class AsciiDocAnchorWithoutIdInspectionTest extends AsciiDocQuickFixTestB
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocAnchorWithoutIdInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocAttributeContinuationInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocAttributeContinuationInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocAttributeContinuationInspectionTest extends AsciiDocQuickFi
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocAttributeContinuationInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocAttributeUndefinedInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocAttributeUndefinedInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocAttributeUndefinedInspectionTest extends AsciiDocQuickFixTe
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocAttributeUndefinedInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocBlockMacroShouldBeInlineMacroInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocBlockMacroShouldBeInlineMacroInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocBlockMacroShouldBeInlineMacroInspectionTest extends AsciiDo
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocBlockMacroShouldBeInlineMacroInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocCreateMissingFileInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocCreateMissingFileInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocCreateMissingFileInspectionTest extends AsciiDocQuickFixTes
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocPageBreakInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocDescriptionExistsInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocDescriptionExistsInspectionTest.java
@@ -5,7 +5,7 @@ public class AsciiDocDescriptionExistsInspectionTest extends AsciiDocQuickFixTes
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocDescriptionExistsInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocDescriptionLengthInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocDescriptionLengthInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocDescriptionLengthInspectionTest extends AsciiDocQuickFixTes
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocDescriptionLengthInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocDiagramInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocDiagramInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocDiagramInspectionTest extends AsciiDocQuickFixTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocLinkResolveInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocGrammarInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocGrammarInspectionTest.java
@@ -15,7 +15,7 @@ public class AsciiDocGrammarInspectionTest extends AsciiDocQuickFixTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(GrazieInspection.class, SpellCheckingInspection.class);
     PlatformTestUtil.dispatchAllEventsInIdeEventQueue();
   }

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocHeadingStyleInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocHeadingStyleInspectionTest.java
@@ -8,7 +8,7 @@ public class AsciiDocHeadingStyleInspectionTest extends AsciiDocQuickFixTestBase
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocHeadingStyleInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocHorizontalRuleInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocHorizontalRuleInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocHorizontalRuleInspectionTest extends AsciiDocQuickFixTestBa
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocHorizontalRuleInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocInlineMacroShouldBeBlockOrPreprocessorMacroInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocInlineMacroShouldBeBlockOrPreprocessorMacroInspectionTest.java
@@ -5,7 +5,7 @@ public class AsciiDocInlineMacroShouldBeBlockOrPreprocessorMacroInspectionTest e
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocInlineMacroShouldBeBlockOrPreprocessorMacroInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocInspectionSuppressorTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocInspectionSuppressorTest.java
@@ -9,7 +9,7 @@ public class AsciiDocInspectionSuppressorTest extends AsciiDocQuickFixTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocLinkResolveInspection.class, AsciiDocReferencePatternInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocLinkResolveInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocLinkResolveInspectionTest.java
@@ -12,7 +12,7 @@ public class AsciiDocLinkResolveInspectionTest extends AsciiDocQuickFixTestBase 
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocLinkResolveInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocListingStyleInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocListingStyleInspectionTest.java
@@ -12,7 +12,7 @@ public class AsciiDocListingStyleInspectionTest extends AsciiDocQuickFixTestBase
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocListingStyleInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocPageBreakInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocPageBreakInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocPageBreakInspectionTest extends AsciiDocQuickFixTestBase {
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocPageBreakInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocReferencePatternInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocReferencePatternInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocReferencePatternInspectionTest extends AsciiDocQuickFixTest
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocReferencePatternInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocXrefWithNaturalCrossReferenceInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocXrefWithNaturalCrossReferenceInspectionTest.java
@@ -9,7 +9,7 @@ public class AsciiDocXrefWithNaturalCrossReferenceInspectionTest extends AsciiDo
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocXrefWithNaturalCrossReferenceInspection.class);
   }
 

--- a/src/test/java/org/asciidoc/intellij/inspections/AsciiDocXrefWithoutExtensionInspectionTest.java
+++ b/src/test/java/org/asciidoc/intellij/inspections/AsciiDocXrefWithoutExtensionInspectionTest.java
@@ -13,7 +13,7 @@ public class AsciiDocXrefWithoutExtensionInspectionTest extends AsciiDocQuickFix
   @Override
   public void setUp() throws Exception {
     super.setUp();
-    //noinspection unchecked
+    // noinspection unchecked
     myFixture.enableInspections(AsciiDocXrefWithoutExtensionInspection.class);
   }
 


### PR DESCRIPTION
Fix to remove a space between line comment marker and the following text

## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [x] Other, please describe: Java Comment fix

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

<!-- If yes, please describe the breaking change below -->

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/CONTRIBUTING.adoc) document.
- [x] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx` (where `xxx` is the issue number).
- [x] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.
- [ ] I have added tests to cover the changes in the code.
- [ ] I need help writing a test (Maintainers are willing to help).

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

<!-- Please add any additional remarks below -->

