### PR TITLE
Add error message in preview when loading the custom stylesheet fails (#1076)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -7,6 +7,10 @@ This document provides a high-level view of the changes introduced by release.
 [[releasenotes]]
 == Release notes
 
+=== 0.37.52
+
+- Add error message in preview when loading the custom stylesheet fails (#1076)
+
 === 0.37.51
 
 - Convert formatted text from clipboard on paste (#75)

--- a/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java
+++ b/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java
@@ -1309,7 +1309,7 @@ public class AsciiDocWrapper {
         // a background color as a background color is necessary for OSR JCEF preview
         // https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/954
         html = html
-          .replace("<head>", "<head>" + "<link rel='stylesheet' type='text/css' href='" + css + "' onload=\"document.head.querySelectorAll('[data-default]').forEach(e => e.remove())\" />" +
+          .replace("<head>", "<head>" + "<link rel='stylesheet' type='text/css' href='" + css + "' onload=\"document.head.querySelectorAll('[data-default]').forEach(e => e.remove())\" onerror=\"var node = document.getElementById('mathjaxerrortext'); var text = document.createTextNode('Unable to load custom stylesheet, check if URL is valid and accessible: ' + this.href); node.parentNode.insertBefore(text, node) \" />" +
             "<style>body { background-color: rgb(255, 255, 255); }</style>" + standardCss);
       } else {
         // custom stylesheet set


### PR DESCRIPTION
## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

This now shows an error message in the preview is loading of the stylesheet fails: 

![image](https://user-images.githubusercontent.com/3957921/193452614-9b8ee69e-8fb2-4ac0-a26f-9f73fc3f3d68.png)

