### PR TITLE
fix #601 : add space for line comment prefix

### DIFF
--- a/src/main/java/org/asciidoc/intellij/AsciiDocCommenter.java
+++ b/src/main/java/org/asciidoc/intellij/AsciiDocCommenter.java
@@ -10,7 +10,7 @@ public class AsciiDocCommenter implements Commenter {
   @Nullable
   @Override
   public String getLineCommentPrefix() {
-    return "//";
+    return "// ";
   }
 
   @Nullable


### PR DESCRIPTION
## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other, please describe: enhancement

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

<!-- If yes, please describe the breaking change below -->

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/CONTRIBUTING.adoc) document.
- [x] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx` (where `xxx` is the issue number).
- [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.
- [ ] I have added tests to cover the changes in the code.
- [x] I need help writing a test (Maintainers are willing to help).

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

<!-- Please add any additional remarks below -->
I tested the described wanted behaviour in #601. Text is now commented out with leading "// " and commented out text is uncommented correctly for comments with old prefix ("//test") as well as with new prefix ("// test"). But I don't know how to write a test for that because the affected class AsciiDocCommenter.java doesn't have a test class (yet).
