### PR TITLE
Fix extra backticks in smart single quotes (#1286)

### DIFF
--- a/src/main/java/org/asciidoc/intellij/actions/FormattingQuotedTypedHandler.java
+++ b/src/main/java/org/asciidoc/intellij/actions/FormattingQuotedTypedHandler.java
@@ -59,7 +59,7 @@ public class FormattingQuotedTypedHandler extends TypedHandlerDelegate {
         int border = 0;
         if (newText == null) {
           boolean word = FormatAsciiDocAction.isWord(editor.getDocument(), selectionStart, selectionEnd, "" + c);
-          if (word || c == '"' || c == '\'' || c == '~' || c == '^') {
+          if (word || c == '"' || c == '\'' || c == '~' || c == '^' || c == '`') {
             newText = c + selectedText + c;
             border = 1;
           } else {


### PR DESCRIPTION
```
boolean word = FormatAsciiDocAction.isWord(editor.getDocument(), selectionStart, selectionEnd, "" + c);
if (word || c == '"' || c == '\'' || c == '~' || c == '^') {
```

Explanation: word was true for "` so it appeared to work when the selection was on word boundaries and double quotes were used, but
- word is false for '` (see the isWord method), so it was not detected correctly
- selection outside word boundaries wouldn't work with backticks at all => needs to test explicitly that the previous character is a backtick

## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

<!-- If yes, please describe the breaking change below -->

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/CONTRIBUTING.adoc) document.
- [x] I have given my PR a descriptive name. If it resolves a specific issue, I referenced it in the form of `fix #xxx` (where `xxx` is the issue number).
- [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.
- [ ] I have added tests to cover the changes in the code.
- [ ] I need help writing a test (Maintainers are willing to help).

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

<!-- Please add any additional remarks below -->

I could build the plugin and test it manually, it was fine.
**Two unit tests didn't pass** but they don't pass with the unmodified repo either:
- AsciiDocWrapperTest
  - testShouldRenderPlantUmlAsPng
- AsciiDocCreateMissingFileInspectionTest
  - testCreateMissingIncludeFile