### PR TITLE
Use latest mechanism to auto-download plugins for Qodana

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,41 +38,26 @@ jobs:
         with:
           fetch-depth: ${{ github.event.pull_request.commits }}
 
-      - name: Download AsciiDoc plugin for AsciiDoc checks
-        run: |
-          curl -L -o asciidoctor-intellij-plugin.zip https://github.com/asciidoctor/asciidoctor-intellij-plugin/releases/download/0.38.2/asciidoctor-intellij-plugin-0.38.2.zip
-          unzip asciidoctor-intellij-plugin.zip
-
-      - name: Download Grazie plugin for grammar checks
-        # https://plugins.jetbrains.com/plugin/12175-grazie/versions
-        run: |
-          curl -L -o grazie.zip 'https://plugins.jetbrains.com/plugin/download?rel=true&updateId=257026'
-          unzip grazie.zip
-
-      - name: Download Grazie Professional plugin for grammar checks
-        # https://plugins.jetbrains.com/plugin/16136-grazie-professional/versions
-        run: |
-          curl -L -o grazie-pro.zip 'https://plugins.jetbrains.com/plugin/download?rel=true&updateId=260567'
-          unzip grazie-pro.zip
-
       - name: Get one more commit so Qodana we can identify the changes
         if: github.event_name == 'pull_request'
         run: git fetch --deepen=1
+
+      - name: Create empty folder to overwrite disabled plugin
+        run: |
+          mkdir empty
 
       - name: 'Qodana for Docs'
         uses: JetBrains/qodana-action@v2022.3.4
         with:
           # https://hub.docker.com/r/jetbrains/qodana-jvm-community/tags
-          # this disables the Gradle plugin to avoid the Gradle initializiation and the dependency download
+          # this disables the Gradle plugin to avoid the Gradle initialization and the dependency download
           # as that is not necessary for the Grazie and AsciiDoc plugins to check spelling and links.
           # TODO: the plugin `org.jetbrains.plugins.gradle` should also be suppressed, but the parameter doesn't allow
-          # a comma when called from the Qodana action.
+          # a comma when called from the Qodana action. Therefore overwrite it with an empty folder.
           args: >
-            --linter,jetbrains/qodana-jvm-community:2022.3,
+            --linter,jetbrains/qodana-jvm-community:2023.1,
             --property=idea.suppressed.plugins.id=com.intellij.gradle,
-            -v,${{ github.workspace }}/grazie:/opt/idea/plugins/grazie,
-            -v,${{ github.workspace }}/grazie-pro:/opt/idea/plugins/grazie-pro,
-            -v,${{ github.workspace }}/asciidoctor-intellij-plugin:/opt/idea/plugins/asciidoctor-intellij-plugin,
+            -v,${{ github.workspace }}/empty:/opt/idea/plugins/gradle-java,
             --baseline,doc/qodana-baseline.sarif.json
 
       # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-that-runs-the-eslint-analysis-tool

--- a/doc/users-guide/modules/ROOT/pages/features/advanced/validation-cicd.adoc
+++ b/doc/users-guide/modules/ROOT/pages/features/advanced/validation-cicd.adoc
@@ -107,8 +107,5 @@ include::example$workflow-docs.yml[tags=!cleanup]
 The following issues in the Qodana issue tracker are open.
 Voting for them will make this integration simpler.
 
-* https://youtrack.jetbrains.com/issue/QD-1291[QD-1291^]
-Qodana easy plugin installation
 * https://youtrack.jetbrains.com/issue/QD-1290[QD-1290^]
 Add soft wrap to code preview
-

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,11 @@
 version: 1.0
 profile:
   path: doc/asciidoc-inspection.xml
+plugins:
+  # Quodana plugin ('tanvd.grazi') is already installed, no need to download it again
+  - id: com.intellij.grazie.pro
+  # Order of plugin in the order which they depend on. AsciiDoc depends on Qodana pro, therefore add it after
+  - id: org.asciidoctor.intellij.asciidoc
 exclude:
   - name: All
     paths:


### PR DESCRIPTION
<!--
Thank you for contributing!
You can find more information in the contributing guide:
https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/index.html
-->

## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

<!-- If yes, please describe the breaking change below -->

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
- [x] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

