### PR TITLE
Work in progress - Add epub support for the IntelliJ Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,7 @@ dependencies {
    */
   implementation 'org.snakeyaml:snakeyaml-engine:2.6'
   implementation 'org.asciidoctor:asciidoctorj:2.5.10' // WARNING: when upgrading asciidoctorj, see comment above about snakeyaml!
+  implementation 'org.asciidoctor:asciidoctorj-epub3:1.5.1'
   implementation 'commons-io:commons-io:2.13.0'
   // used to be 'nl.jworks.markdown_to_asciidoc:markdown_to_asciidoc:1.1' that is only available on jcenter/bintray
   implementation files('libs/markdown_to_asciidoc-1.1-p1.jar')
@@ -143,6 +144,7 @@ dependencies {
   // when updating the versions here, also update them in AsciiDocDownloaderUtil for dynamic download
   testImplementation 'org.asciidoctor:asciidoctorj-diagram:2.2.9'
   testImplementation 'org.asciidoctor:asciidoctorj-pdf:2.3.7'
+  testImplementation 'org.asciidoctor:asciidoctorj-epub3:1.5.1'
 
   testImplementation(gradleTestKit())
   testRuntimeOnly('org.junit.platform:junit-platform-launcher:1.9.3')

--- a/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java
+++ b/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java
@@ -501,8 +501,8 @@ public class AsciiDocWrapper {
     boolean epubPresent = AsciiDocDownloaderUtil.getAsciidoctorJEpubFile().exists();
     if (!epubPresent) {
       // try to find it in the class path for tests
-      try (InputStream is = this.getClass().getResourceAsStream("/gems/asciidoctor-pdf-" +
-        AsciiDocDownloaderUtil.ASCIIDOCTORJ_EPUB_VERSION + "/lib/asciidoctor-pdf.rb")) {
+      try (InputStream is = this.getClass().getResourceAsStream("/gems/asciidoctor-epub3-" +
+        AsciiDocDownloaderUtil.ASCIIDOCTORJ_EPUB_VERSION + "/lib/asciidoctor-epub3.rb")) {
         if (is != null) {
           epubPresent = true;
         }

--- a/src/main/java/org/asciidoc/intellij/actions/asciidoc/CreateEpubAction.java
+++ b/src/main/java/org/asciidoc/intellij/actions/asciidoc/CreateEpubAction.java
@@ -1,0 +1,128 @@
+package org.asciidoc.intellij.actions.asciidoc;
+
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import org.asciidoc.intellij.AsciiDocBundle;
+import org.asciidoc.intellij.AsciiDocExtensionService;
+import org.asciidoc.intellij.AsciiDocWrapper;
+import org.asciidoc.intellij.download.AsciiDocDownloadNotificationProvider;
+import org.asciidoc.intellij.download.AsciiDocDownloaderUtil;
+import org.asciidoc.intellij.psi.AsciiDocUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+
+public class CreateEpubAction extends AsciiDocFileAction {
+  public static final String ID = "org.asciidoc.intellij.actions.asciidoc.CreateEpubAction";
+  private static final Logger LOG = Logger.getInstance(CreateEpubAction.class);
+  private final AsciiDocExtensionService extensionService = ApplicationManager.getApplication().getService(AsciiDocExtensionService.class);
+
+
+  @Override
+  public boolean displayTextInToolbar() {
+    return true;
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+//    LOG.warn("is it even getting in here");
+    var project = event.getProject();
+    if (project == null) {
+      return;
+    }
+
+    var editor = FileEditorManager.getInstance(project).getSelectedTextEditor();
+    if (editor == null) {
+      return;
+    }
+
+    var file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+    if (file == null) {
+      return;
+    }
+    if (file.getCanonicalPath() == null) {
+      return;
+    }
+
+    if (!AsciiDocDownloaderUtil.downloadCompleteAsciidoctorJEpub()) {
+      // download all element, as we can't detect if the EPUB contains maybe diagrams
+      AsciiDocDownloaderUtil.downloadAsciidoctorJEpub(project, () -> {
+        Notifications.Bus
+          .notify(new Notification("asciidoctor", AsciiDocBundle.message("asciidoc.download.title"),
+            AsciiDocBundle.message("asciidoc.download.asciidoctorj-epub3.success"),
+            NotificationType.INFORMATION));
+        this.actionPerformed(event);
+      }, e -> LOG.warn("unable to download", e));
+      return;
+    }
+
+    if (FileDocumentManager.getInstance().getUnsavedDocuments().length > 0) {
+      ApplicationManager.getApplication().runWriteAction(() -> {
+        try {
+          for (Document unsavedDocument : FileDocumentManager.getInstance().getUnsavedDocuments()) {
+            FileDocumentManager.getInstance().saveDocument(unsavedDocument);
+          }
+        } catch (RuntimeException ex) {
+          LOG.warn("Unable to save other file (might be a problem in another plugin", ex);
+        }
+      });
+    }
+    VirtualFile parent = file.getParent();
+    boolean successful = ProgressManager.getInstance().runProcessWithProgressSynchronously(() -> {
+      Path tempImagesPath = null;
+      try {
+        File fileBaseDir = new File("");
+        if (parent != null && parent.getCanonicalPath() != null) {
+          // parent will be null if we use Language Injection and Fragment Editor
+          fileBaseDir = new File(parent.getCanonicalPath());
+          tempImagesPath = AsciiDocWrapper.tempImagesPath(fileBaseDir.toPath(), project);
+        }
+        AsciiDocWrapper asciiDocWrapper = new AsciiDocWrapper(project, fileBaseDir, tempImagesPath, file.getName());
+        List<String> extensions = extensionService.getExtensions(project);
+        String config = AsciiDocWrapper.config(editor.getDocument(), project);
+        asciiDocWrapper.convertTo(new File(file.getCanonicalPath()), config, extensions, AsciiDocWrapper.FileType.EPUB);
+        if (Objects.equals("true", asciiDocWrapper.getAttributes().get("asciidoctor-diagram-missing-diagram-extension"))) {
+          AsciiDocDownloadNotificationProvider.showNotification();
+        }
+      } finally {
+        AsciiDocWrapper.cleanupImagesPath(tempImagesPath);
+      }
+    }, "Creating EPUB", true, project);
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      VirtualFile virtualFileEpub = changeFileExtension(file);
+      VirtualFile virtualFile = virtualFileEpub != null ? virtualFileEpub : parent;
+      AsciiDocUtil.selectFileInProjectView(project, virtualFile);
+      if (virtualFileEpub != null) {
+        if (successful) {
+          new OpenFileDescriptor(project, virtualFileEpub).navigate(true);
+        }
+      }
+    });
+  }
+
+  @Nullable
+  private VirtualFile changeFileExtension(VirtualFile file) {
+    Path path = file.getFileSystem().getNioPath(file);
+    if (path == null) {
+      return null;
+    }
+    return VirtualFileManager.getInstance().refreshAndFindFileByNioPath(
+      path.getParent().resolve(file.getName().replaceAll("\\.(adoc|asciidoc|ad)$", ".epub"))
+    );
+  }
+
+}

--- a/src/main/java/org/asciidoc/intellij/download/AsciiDocDownloaderUtil.java
+++ b/src/main/java/org/asciidoc/intellij/download/AsciiDocDownloaderUtil.java
@@ -65,6 +65,8 @@ public class AsciiDocDownloaderUtil {
   // https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj-pdf
   public static final String ASCIIDOCTORJ_PDF_VERSION = "2.3.7";
   private static final String ASCIIDOCTORJ_PDF_HASH = "9c3d8e8f9ce10ecef50ff7b2456562f4e43abbbded2a1a36bdfab8c7096be1c7";
+  public static final String ASCIIDOCTORJ_EPUB_VERSION = "1.5.1";
+  private static final String ASCIIDOCTORJ_EPUB_HASH = "8b66d1a90a2719fe63b1e6ad51d82f6bb114ab66cda93dbcdd7335d0f1f602f7";
 
   // when updating the version, also update the sha256 hash!
   // https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj-diagram
@@ -106,8 +108,18 @@ public class AsciiDocDownloaderUtil {
     return file.exists();
   }
 
+  public static boolean downloadCompleteAsciidoctorJEpub() {
+    var file = getAsciidoctorJEpubFile();
+    return file.exists();
+  }
+
   public static File getAsciidoctorJPdfFile() {
     String fileName = DOWNLOAD_PATH + File.separator + "asciidoctorj-pdf-" + ASCIIDOCTORJ_PDF_VERSION + ".jar";
+    return new File(fileName);
+  }
+
+  public static File getAsciidoctorJEpubFile() {
+    var fileName = DOWNLOAD_PATH + File.separator + "asciidoctorj-epub3-" + ASCIIDOCTORJ_EPUB_VERSION + ".jar";
     return new File(fileName);
   }
 
@@ -300,11 +312,25 @@ public class AsciiDocDownloaderUtil {
     download(downloadName, url, ASCIIDOCTORJ_PDF_HASH, project, onSuccess, onFailure);
   }
 
+  public static void downloadAsciidoctorJEpub(@Nullable Project project, @NotNull Runnable onSuccess, @NotNull Consumer<Throwable> onFailure) {
+    String downloadName = "asciidoctorj-epub3-" + ASCIIDOCTORJ_EPUB_VERSION + ".jar";
+    String url = getAsciidoctorJEpubUrl();
+    download(downloadName, url, ASCIIDOCTORJ_EPUB_HASH, project, onSuccess, onFailure);
+  }
+
   public static String getAsciidoctorJPdfUrl() {
     return "https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj-pdf/" +
       ASCIIDOCTORJ_PDF_VERSION +
       "/asciidoctorj-pdf-" +
       ASCIIDOCTORJ_PDF_VERSION +
+      ".jar";
+  }
+
+  public static String getAsciidoctorJEpubUrl() {
+    return "https://repo1.maven.org/maven2/org/asciidoctor/asciidoctorj-epub3/" +
+      ASCIIDOCTORJ_EPUB_VERSION +
+      "/asciidoctorj-epub3-" +
+      ASCIIDOCTORJ_EPUB_VERSION +
       ".jar";
   }
 

--- a/src/main/resources/AsciiDocBundle.properties
+++ b/src/main/resources/AsciiDocBundle.properties
@@ -873,6 +873,7 @@ asciidoc.download.title=AsciiDoc download
 asciidoc.download.asciidoctorj-diagram.success=Download of asciidoctorj-diagram successful
 asciidoc.download.failed=Download failed
 asciidoc.download.asciidoctorj-pdf.success=Download of asciidoctorj-pdf successful
+asciidoc.download.asciidoctorj-epub3.success=Download of asciidoctorj-epub3 successful
 asciidoc.download.dependencies=Download AsciiDoc dependencies for diagrams and PDF creation (ca. 17 MB)
 asciidoc.download.folderandcontents=This requires an internet connection. {0} will be downloaded to {1}. If you do not download the files now, they will be downloaded on-demand when needed given an internet connection is available at the time.
 asciidoc.download.complete=Download of dependencies for diagrams and PDF creation complete

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -115,6 +115,11 @@
                 text="PDF"
                 description="Create PDF from current file">
         </action>
+        <action class="org.asciidoc.intellij.actions.asciidoc.CreateEpubAction"
+                id="org.asciidoc.intellij.actions.asciidoc.CreateEpubAction"
+                text="EPUB"
+                description="Create EPUB from current file">
+        </action>
         <action class="org.asciidoc.intellij.actions.asciidoc.CreateDocxAction"
                 id="org.asciidoc.intellij.actions.asciidoc.CreateDocxAction"
                 text="DOCX"

--- a/src/main/resources/epub-antora.rb
+++ b/src/main/resources/epub-antora.rb
@@ -1,0 +1,28 @@
+require 'java'
+require 'asciidoctor/epub3'
+
+include ::Asciidoctor
+
+# resolve Antora references
+
+module ResolveAntoraEpub
+  def convert_inline_anchor(node)
+    if node.type == :xref
+      org.asciidoc.intellij.asciidoc.AntoraReferenceAdapter.convertInlineAnchor(node)
+    end
+    super(node)
+  end
+  def convert_inline_image(node)
+    org.asciidoc.intellij.asciidoc.AntoraReferenceAdapter.convertInlineImage(node)
+    super(node)
+  end
+  def convert_image(node, opts = {})
+    org.asciidoc.intellij.asciidoc.AntoraReferenceAdapter.convertImage(node)
+    super(node, opts)
+  end
+end
+
+class Asciidoctor::EPUB::Converter < ::Prawn::Document
+  prepend ResolveAntoraEpub
+end
+


### PR DESCRIPTION
### Please keep in mind that this is a work in progress, but I got stuck and I would like to know if this feature is not currently in progress so that this work is not thrown away and also I would like to get some guidance as I'm currently stuck

### What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other, please describe:

Does this PR introduce a breaking change?

- [x] No
- [ ] Yes

Checklist:

- [ ]  I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

Right now most of the code it's a copy of the PDF Converter adapted to use the EPUB converter, I added the EPUB java library directly as it seems that this library is not part of the aciidocj yet, my plan is just to get it working and then check if I can add it to the main asciidocj.

So far I if you could help me with this questions:

Is some one working on this already?
is there any material that I can use for reference to import the gem `asciidoctor/epub3` in the file `src/main/resources/epub-antora.rb` so that it can be picked in the file `src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java`

Looking at the way that the gem for the pdf is loaded makes me think that the asciidoctorj is the one in charge of loading the gems in the classpath so that they are available in java