### PR TITLE
Fix for CLion 2025.1 EAP

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@ This document provides a high-level view of the changes introduced by release.
 
 === 0.44.2
 
-...
+- Fix compatibility with Python in CLion EAP 2025.1 (#1778, thanks to @peci1)
 
 === 0.44.1
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -373,7 +373,7 @@
     <psi.referenceContributor implementation="org.asciidoc.intellij.findUsages.AsciiDocIncludeTagReferenceContributor" language="" />
     <referencesSearch implementation="org.asciidoc.intellij.findUsages.AsciiDocIdReferencesSearch"/>
     <completion.contributor language="AsciiDoc" implementationClass="org.asciidoc.intellij.completion.AsciiDocCompletionContributor"/>
-    <lookup.charFilter implementation="org.asciidoc.intellij.completion.AsciiDocCharFilter" order="before java" />
+    <lookup.charFilter implementation="org.asciidoc.intellij.completion.AsciiDocCharFilter" order="before java" id="asciidoc"/>
     <lang.documentationProvider language="AsciiDoc" implementationClass="org.asciidoc.intellij.AsciiDocDocumentationProvider"/>
     <httpRequestHandler implementation="org.asciidoc.intellij.editor.javafx.PreviewStaticServer"/>
     <completion.contributor language="AsciiDoc"

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -373,7 +373,7 @@
     <psi.referenceContributor implementation="org.asciidoc.intellij.findUsages.AsciiDocIncludeTagReferenceContributor" language="" />
     <referencesSearch implementation="org.asciidoc.intellij.findUsages.AsciiDocIdReferencesSearch"/>
     <completion.contributor language="AsciiDoc" implementationClass="org.asciidoc.intellij.completion.AsciiDocCompletionContributor"/>
-    <lookup.charFilter implementation="org.asciidoc.intellij.completion.AsciiDocCharFilter" order="before java" id="default"/>
+    <lookup.charFilter implementation="org.asciidoc.intellij.completion.AsciiDocCharFilter" order="before java" />
     <lang.documentationProvider language="AsciiDoc" implementationClass="org.asciidoc.intellij.AsciiDocDocumentationProvider"/>
     <httpRequestHandler implementation="org.asciidoc.intellij.editor.javafx.PreviewStaticServer"/>
     <completion.contributor language="AsciiDoc"


### PR DESCRIPTION
Closes #1778

## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

I don't know. Hopefully not.

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
- [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

---

CLion 2025.1 EAP does not work with AsciiDoc - it blocks typing in Python scripts. Issue reported here: https://youtrack.jetbrains.com/issue/CPP-43240 .

The fix I'm sending was proposed by Jetbrains support in https://youtrack.jetbrains.com/issue/CPP-43240/Cannot-type-more-than-1-letter-in-Python-scripts#focus=Comments-27-11542597.0-0 .

I've locally tested the fix and it works for me (at least regarding not breaking Python coding).

Credit goes to Alexander Karaev from JB.