### PR TITLE
Fix a CI deprecation warning: replace `version` with `release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           environment: production
-          version: ${{ github.ref }}
+          release: ${{ github.ref }}
           inject: false
   cleanup:
     name: Cleanup old builds


### PR DESCRIPTION
<!--
Thank you for contributing!
You can find more information in the contributing guide:
https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/index.html
-->

The `getsentry/action-release` action is currently throwing deprecation warnings in CI [[recent example](https://github.com/asciidoctor/asciidoctor-intellij-plugin/actions/runs/23940898574)]:

> <img width="711" height="214" alt="image" src="https://github.com/user-attachments/assets/deba1dd4-295b-4563-926b-2f8f659ebf95" />

[The `version` input deprecation is documented](https://github.com/getsentry/action-release#parameters). This PR changes the input key from `version` to `release`, as documented.


## What kind of change does this PR introduce?
<!-- Place an `x` in all the boxes that apply -->
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
<!-- Place an `x` in one of the boxes -->
- [x] No
- [ ] Yes

<!-- If yes, please describe the breaking change below -->

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
- [ ] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.

Creating the pull request triggers some automated tests.
See the [chapter building in the contributor's guide](https://intellij-asciidoc-plugin.ahus1.de/docs/contributors-guide/coder/building-and-running.html) to find out how to run them on your local machine.

