### PR TITLE
Resolve Antora example$ resource ids in the Kroki PlantUML integration (#516)

### DIFF
--- a/doc/users-guide/modules/ROOT/pages/features/advanced/antora.adoc
+++ b/doc/users-guide/modules/ROOT/pages/features/advanced/antora.adoc
@@ -50,6 +50,10 @@ For this it searches all available `antora.yml` files in the current project.
 
 For `include::[]` macros the plugin supports the Antora families like `partial$`, `example$` and `page$`.
 
+When Kroki is enabled, the plugin also resolves `example$` resource ids used as a
+`+plantuml::example$...[]+` diagram target and inside PlantUML `+!include+` / `+!includesub+`
+directives, inlining the referenced files before the diagram is sent to Kroki.
+
 [NOTE]
 ====
 Using Antora page families and includes works in the preview only for trusted project and when IDE is running in the default UNSAFE mode.

--- a/doc/users-guide/modules/ROOT/pages/features/preview/diagrams.adoc
+++ b/doc/users-guide/modules/ROOT/pages/features/preview/diagrams.adoc
@@ -111,6 +111,16 @@ To avoid this, consider using `interactive` for Kroki diagrams as an alternative
 See <<interative-vs-inlined>> and <<avoid-flicker>> for a discussion of tradeoffs.
 ====
 
+=== Antora resource ids in Kroki diagrams
+
+When editing inside an Antora module with Kroki enabled, the plugin resolves Antora `example$`
+resource ids both as a diagram target (`+plantuml::example$dir/file.puml[]+`) and inside PlantUML
+`+!include+` / `+!includesub+` directives.
+Because the Kroki server has no access to the local file system, the referenced files are inlined
+into the diagram before it is sent to Kroki.
+An `example$` reference that cannot be resolved fails the diagram with a clear error rather than
+rendering it incompletely.
+
 == Using embedded Mermaid support
 
 As an experimental option in plugin version 0.38.1+, there's an embedded Mermaid support that is embedded in the plugin and will render Mermaid diagrams within the IDE without external helpers.

--- a/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java
+++ b/src/main/java/org/asciidoc/intellij/AsciiDocWrapper.java
@@ -440,6 +440,15 @@ public class AsciiDocWrapper {
             }
             asciidoctor.rubyExtensionRegistry().loadClass(is);
           }
+          // Antora support for Kroki: resolve example$/partial$ resource ids in diagram targets and
+          // inline PlantUML !include directives (no-op outside an Antora module). Must load after
+          // kroki-extension.rb as it prepends onto its classes.
+          try (InputStream is = this.getClass().getResourceAsStream("/kroki-antora.rb")) {
+            if (is == null) {
+              throw new RuntimeException("unable to load script kroki-antora.rb");
+            }
+            asciidoctor.rubyExtensionRegistry().loadClass(is);
+          }
         }
 
         if (format.backend.equals("html5") && asciiDocApplicationSettings.getAsciiDocPreviewSettings().isEnableBuiltInMermaid()) {

--- a/src/main/java/org/asciidoc/intellij/asciidoc/AntoraReferenceAdapter.java
+++ b/src/main/java/org/asciidoc/intellij/asciidoc/AntoraReferenceAdapter.java
@@ -62,6 +62,44 @@ public class AntoraReferenceAdapter {
     convertAntora(node, "video");
    }
 
+  /**
+   * Resolve an Antora resource identifier (for example {@code example$diagram.puml}, {@code partial$x.puml})
+   * to an absolute path on the local file system, relative to the current Antora module.
+   * <p>
+   * Used by the Kroki extension ({@code kroki-antora.rb}) to resolve diagram block-macro targets and
+   * PlantUML {@code !include} directives, which Asciidoctor does not resolve on its own (see
+   * <a href="https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/516">#516</a>).
+   *
+   * @param target an Antora resource id, possibly with a family prefix
+   * @return the absolute file system path, or {@code null} if not in an Antora module, not a resource id,
+   * a URL, or not resolvable (callers should then fall back to the unmodified target)
+   */
+  public static String resolveAntoraResourcePath(String target) {
+    if (antoraModuleDir == null || target == null || target.isEmpty()) {
+      return null;
+    }
+    if (URL_PREFIX_PATTERN.matcher(target).find()) {
+      return null;
+    }
+    Matcher matcher = ANTORA_PREFIX_AND_FAMILY_PATTERN.matcher(target);
+    if (!matcher.find()) {
+      // no Antora family/prefix (e.g. a plain relative path or a PlantUML standard library include) -> leave to caller
+      return null;
+    }
+    if (matcher.group().length() == 2 && matcher.group().charAt(1) == ':' && target.length() > 2 && target.charAt(2) == '/') {
+      // probably an already expanded windows path name (c:/...)
+      return null;
+    }
+    VirtualFile sourceDir = LocalFileSystem.getInstance().findFileByIoFile(fileBaseDir);
+    // diagram sources are commonly kept in the example family; the explicit prefix in the target wins anyway
+    List<String> replaced = AsciiDocUtil.replaceAntoraPrefix(project, antoraModuleDir, sourceDir, target, "example");
+    if (replaced.isEmpty() || (replaced.size() == 1 && replaced.get(0).equals(target))) {
+      // unable to replace
+      return null;
+    }
+    return replaced.get(0);
+  }
+
   @SuppressWarnings("checkstyle:MethodLength")
   public static void convertAntora(RubyObject node, String type) {
     if (antoraModuleDir != null) {

--- a/src/main/java/org/asciidoc/intellij/asciidoc/AntoraReferenceAdapter.java
+++ b/src/main/java/org/asciidoc/intellij/asciidoc/AntoraReferenceAdapter.java
@@ -81,19 +81,22 @@ public class AntoraReferenceAdapter {
     if (URL_PREFIX_PATTERN.matcher(target).find()) {
       return null;
     }
-    Matcher matcher = ANTORA_PREFIX_AND_FAMILY_PATTERN.matcher(target);
+    // Antora may present a family-only resource id in its empty-module form, e.g. ":example$path";
+    // a leading colon means "current module", so strip it before resolving.
+    String normalized = target.startsWith(":") ? target.substring(1) : target;
+    Matcher matcher = ANTORA_PREFIX_AND_FAMILY_PATTERN.matcher(normalized);
     if (!matcher.find()) {
       // no Antora family/prefix (e.g. a plain relative path or a PlantUML standard library include) -> leave to caller
       return null;
     }
-    if (matcher.group().length() == 2 && matcher.group().charAt(1) == ':' && target.length() > 2 && target.charAt(2) == '/') {
+    if (matcher.group().length() == 2 && matcher.group().charAt(1) == ':' && normalized.length() > 2 && normalized.charAt(2) == '/') {
       // probably an already expanded windows path name (c:/...)
       return null;
     }
     VirtualFile sourceDir = LocalFileSystem.getInstance().findFileByIoFile(fileBaseDir);
     // diagram sources are commonly kept in the example family; the explicit prefix in the target wins anyway
-    List<String> replaced = AsciiDocUtil.replaceAntoraPrefix(project, antoraModuleDir, sourceDir, target, "example");
-    if (replaced.isEmpty() || (replaced.size() == 1 && replaced.get(0).equals(target))) {
+    List<String> replaced = AsciiDocUtil.replaceAntoraPrefix(project, antoraModuleDir, sourceDir, normalized, "example");
+    if (replaced.isEmpty() || (replaced.size() == 1 && replaced.get(0).equals(normalized))) {
       // unable to replace
       return null;
     }

--- a/src/main/java/org/asciidoc/intellij/asciidoc/AntoraReferenceAdapter.java
+++ b/src/main/java/org/asciidoc/intellij/asciidoc/AntoraReferenceAdapter.java
@@ -89,7 +89,7 @@ public class AntoraReferenceAdapter {
       // no Antora family/prefix (e.g. a plain relative path or a PlantUML standard library include) -> leave to caller
       return null;
     }
-    if (matcher.group().length() == 2 && matcher.group().charAt(1) == ':' && normalized.length() > 2 && normalized.charAt(2) == '/') {
+    if (isExpandedWindowsPath(matcher, normalized)) {
       // probably an already expanded windows path name (c:/...)
       return null;
     }
@@ -101,6 +101,13 @@ public class AntoraReferenceAdapter {
       return null;
     }
     return replaced.get(0);
+  }
+
+  // The ANTORA_PREFIX_AND_FAMILY_PATTERN also matches an already-expanded Windows path (e.g. "c:/..."),
+  // which must not be treated as an Antora resource id.
+  private static boolean isExpandedWindowsPath(Matcher matcher, String target) {
+    return matcher.group().length() == 2 && matcher.group().charAt(1) == ':'
+      && target.length() > 2 && target.charAt(2) == '/';
   }
 
   @SuppressWarnings("checkstyle:MethodLength")
@@ -136,7 +143,7 @@ public class AntoraReferenceAdapter {
       }
       Matcher matcher = ANTORA_PREFIX_AND_FAMILY_PATTERN.matcher(target);
       if (matcher.find()) {
-        if (matcher.group().length() == 2 && matcher.group().charAt(1) == ':' && target.length() > 2 && target.charAt(2) == '/') {
+        if (isExpandedWindowsPath(matcher, target)) {
           // if the second character is a colon, this is probably an already expanded windows path name
           return;
         }

--- a/src/main/resources/kroki-antora.rb
+++ b/src/main/resources/kroki-antora.rb
@@ -18,6 +18,12 @@ require 'java'
 # See https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/516
 
 module AsciidoctorExtensions
+  # Raised when a PlantUML !include points at an Antora resource id that cannot be resolved/read.
+  # It is allowed to escape the defensive rescues below so the diagram fails loudly with a clear
+  # message — matching the Antora build, asciidoctor and standalone PlantUML, which all bail on a
+  # missing include rather than rendering a silently-incomplete diagram.
+  class UnresolvedAntoraInclude < StandardError; end
+
   # Antora-aware PlantUML preprocessing helpers.
   module AntoraKroki
     PLANTUML_BLOCK_RX = /@startuml(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m
@@ -37,6 +43,12 @@ module AsciidoctorExtensions
 
     def remote?(url)
       url.start_with?('http://') || url.start_with?('https://')
+    end
+
+    # An Antora resource id carries a family marker (e.g. example$, partial$, image$); plain PlantUML
+    # includes (relative paths, stdlib) have none and must pass through untouched.
+    def antora_resource_id?(target)
+      target.include?('$')
     end
 
     # Inline all Antora-resource !include directives in a PlantUML diagram, then strip the @startuml/@enduml
@@ -74,7 +86,13 @@ module AsciidoctorExtensions
       return original if remote?(target)
 
       resolved = resolve(target)
-      return original if resolved.nil? || !::File.readable?(resolved)
+      if resolved.nil? || !::File.readable?(resolved)
+        # A broken Antora resource id is a real authoring error: fail loudly (like the Antora build,
+        # asciidoctor and PlantUML) instead of silently rendering an incomplete diagram. A plain include
+        # (no family marker) is not ours to resolve, so it passes through untouched.
+        raise UnresolvedAntoraInclude, "kroki (antora): cannot resolve PlantUML include '#{target}'" if antora_resource_id?(target)
+        return original
+      end
       return original if include_stack.include?(resolved) # cycle guard
 
       raw = ::File.read(resolved, mode: 'rb:utf-8:utf-8')
@@ -100,6 +118,8 @@ module AsciidoctorExtensions
 
       inlined = process_includes(text, include_once, include_stack + [resolved])
       comment.empty? ? inlined : "#{inlined} #{comment}"
+    rescue UnresolvedAntoraInclude
+      raise # intentional hard failure: must not be swallowed by the defensive rescue below
     rescue StandardError
       original
     end
@@ -162,6 +182,8 @@ module AsciidoctorExtensions
           if %w[plantuml c4plantuml].include?(diagram_type.to_s)
             begin
               diagram_text = AntoraKroki.preprocess(diagram_text)
+            rescue UnresolvedAntoraInclude
+              raise # surface the clear error; don't silently render an incomplete diagram
             rescue StandardError
               # fall back to the unmodified diagram text
             end

--- a/src/main/resources/kroki-antora.rb
+++ b/src/main/resources/kroki-antora.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+require 'java'
+
+# Antora support for the Kroki extension (loaded right after kroki-extension.rb, only when Kroki is enabled).
+#
+# Asciidoctor / the Ruby Kroki extension do not understand Antora resource identifiers. This patch adds:
+#   1. resolution of diagram block-macro targets, e.g.  plantuml::example$dir/file.puml[]
+#   2. inlining of PlantUML !include / !includesub directives that reference Antora resources, e.g.
+#        !include example$dir/layout.puml
+#        !includesub example$dir/model.puml!SomeSub
+#      (the Kroki server has no file-system access, so includes must be inlined before sending).
+#
+# Resolution of an Antora resource id to a local path is delegated to the Java side
+# (AntoraReferenceAdapter#resolveAntoraResourcePath), which reuses the plugin's existing Antora
+# module resolution. Outside an Antora module the resolver returns nil and behavior is unchanged.
+#
+# The include inlining is ported from the asciidoctor-kroki JavaScript extension (preprocess.js).
+# See https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/516
+
+module AsciidoctorExtensions
+  # Antora-aware PlantUML preprocessing helpers.
+  module AntoraKroki
+    PLANTUML_FIRST_BLOCK_RX = /@startuml(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m
+    PLANTUML_BLOCKS_RX = /@startuml(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m
+    INCLUDE_RX = /^\s*!(include(?:_many|_once|url|sub)?)\s+(.*)$/
+
+    module_function
+
+    # Resolve an Antora resource id to an absolute local path, or nil if not resolvable / not a resource id.
+    def resolve(target)
+      org.asciidoc.intellij.asciidoc.AntoraReferenceAdapter.resolveAntoraResourcePath(target)
+    rescue StandardError
+      nil
+    end
+
+    def remote?(url)
+      url.start_with?('http://') || url.start_with?('https://')
+    end
+
+    # Inline all Antora-resource !include directives in a PlantUML diagram, then strip the @startuml/@enduml
+    # tags (the Kroki server adds them back), mirroring the JS extension's preprocessPlantUML.
+    def preprocess(diagram_text)
+      remove_tags(process_includes(diagram_text, [], []))
+    end
+
+    def process_includes(diagram_text, include_once, include_stack)
+      inside_comment = false
+      diagram_text.each_line.map do |line|
+        result = line
+        unless inside_comment
+          if (m = INCLUDE_RX.match(line.chomp))
+            replacement = handle_include(m[1].downcase, m[2], include_once, include_stack)
+            result = replacement.end_with?("\n") ? replacement : "#{replacement}\n"
+          end
+        end
+        inside_comment = true if line.include?("/'")
+        inside_comment = false if inside_comment && line.include?("'/")
+        result
+      end.join
+    end
+
+    # Returns the inlined text for one !include directive, or the original directive line if it can't
+    # (or shouldn't) be resolved as an Antora resource.
+    def handle_include(directive, args, include_once, include_stack)
+      original = "!#{directive} #{args}"
+      url, comment = parse_target(args)
+      url_sub = url.split('!')
+      target = url_sub[0].gsub(/\\ /, ' ').sub(/\s+\z/, '')
+      sub = url_sub[1]
+
+      return original if target.start_with?('<') # PlantUML standard library, resolved by the Kroki server
+      return original if remote?(target)
+
+      resolved = resolve(target)
+      return original if resolved.nil? || !::File.readable?(resolved)
+      return original if include_stack.include?(resolved) # cycle guard
+
+      raw = ::File.read(resolved, mode: 'rb:utf-8:utf-8')
+
+      text =
+        if sub && !sub.empty?
+          if directive == 'includesub'
+            sub_text(raw, sub)
+          elsif sub =~ /\A\d+\z/
+            index_text(raw, sub.to_i)
+          else
+            id_text(raw, sub)
+          end
+        else
+          first_block(raw)
+        end
+
+      if directive == 'include_once'
+        return original if include_once.include?(resolved)
+
+        include_once << resolved
+      end
+
+      inlined = process_includes(text, include_once, include_stack + [resolved])
+      comment.empty? ? inlined : "#{inlined} #{comment}"
+    rescue StandardError
+      original
+    end
+
+    # Split a !include argument into [target, trailing-comment], honoring "# ..." and "/' ... '/" comments.
+    def parse_target(value)
+      i = 3
+      while i < value.length
+        c = value[i]
+        return [value[0...(i - 1)].strip, value[(i - 1)..]] if c == "'" && value[i - 1] == '/' && value[i - 2] != '\\'
+        return [value[0...(i - 1)].strip, value[i..]] if c == '#' && value[i - 1] == ' ' && value[i - 2] != '\\'
+
+        i += 1
+      end
+      [value, '']
+    end
+
+    def first_block(text)
+      (m = text.match(PLANTUML_FIRST_BLOCK_RX)) ? m[1] : text
+    end
+
+    def sub_text(text, sub)
+      collect(text, /!startsub\s+#{Regexp.escape(sub)}(?:\r?\n)([\s\S]*?)(?:\r?\n)!endsub/m)
+    end
+
+    def id_text(text, id)
+      collect(text, /@startuml\(id=#{Regexp.escape(id)}\)(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m)
+    end
+
+    def index_text(text, index)
+      blocks = text.scan(PLANTUML_BLOCKS_RX)
+      blocks[index] ? blocks[index][0] : ''
+    end
+
+    def collect(text, regex)
+      text.scan(regex).map { |g| g[0] }.join("\n")
+    end
+
+    def remove_tags(text)
+      text.gsub(/^[ \t]*@(?:startuml|enduml).*\r?\n?/, '')
+    end
+  end
+
+  # Resolve Antora resource ids used as the block-macro target (plantuml::example$...puml[]).
+  module AntoraKrokiTarget
+    def resolve_target_path(target)
+      AntoraKroki.resolve(target) || super
+    end
+  end
+
+  class KrokiBlockMacroProcessor
+    prepend AntoraKrokiTarget
+  end
+
+  # Inline Antora-resource !include directives for both block (`[plantuml]`) and block-macro forms,
+  # before the diagram text is encoded/sent to Kroki.
+  class KrokiProcessor
+    class << self
+      prepend(Module.new do
+        def process(processor, parent, attrs, diagram_type, diagram_text, logger)
+          if %w[plantuml c4plantuml].include?(diagram_type.to_s)
+            begin
+              diagram_text = AntoraKroki.preprocess(diagram_text)
+            rescue StandardError
+              # fall back to the unmodified diagram text
+            end
+          end
+          super(processor, parent, attrs, diagram_type, diagram_text, logger)
+        end
+      end)
+    end
+  end
+end

--- a/src/main/resources/kroki-antora.rb
+++ b/src/main/resources/kroki-antora.rb
@@ -20,9 +20,11 @@ require 'java'
 module AsciidoctorExtensions
   # Antora-aware PlantUML preprocessing helpers.
   module AntoraKroki
-    PLANTUML_FIRST_BLOCK_RX = /@startuml(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m
-    PLANTUML_BLOCKS_RX = /@startuml(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m
+    PLANTUML_BLOCK_RX = /@startuml(?:\r?\n)([\s\S]*?)(?:\r?\n)@enduml/m
     INCLUDE_RX = /^\s*!(include(?:_many|_once|url|sub)?)\s+(.*)$/
+    # Start of a trailing PlantUML comment in an !include line: an inline " #..." (introduced by a
+    # space) or a block "/'...". A backslash before the marker escapes it (so it is not a comment).
+    COMMENT_RX = %r{(?<!\\) #|(?<!\\)/'}
 
     module_function
 
@@ -102,21 +104,20 @@ module AsciidoctorExtensions
       original
     end
 
-    # Split a !include argument into [target, trailing-comment], honoring "# ..." and "/' ... '/" comments.
+    # Split a "!include" argument into [target, trailing-comment]. The space introducing a "#" comment
+    # is dropped; the "/" of a "/'" comment is kept (matching PlantUML). With no comment the whole
+    # value is the target and the comment is empty.
     def parse_target(value)
-      i = 3
-      while i < value.length
-        c = value[i]
-        return [value[0...(i - 1)].strip, value[(i - 1)..]] if c == "'" && value[i - 1] == '/' && value[i - 2] != '\\'
-        return [value[0...(i - 1)].strip, value[i..]] if c == '#' && value[i - 1] == ' ' && value[i - 2] != '\\'
+      match = COMMENT_RX.match(value)
+      return [value, ''] unless match
 
-        i += 1
-      end
-      [value, '']
+      marker = match.begin(0)
+      comment_start = value[marker] == ' ' ? marker + 1 : marker
+      [value[0...marker].strip, value[comment_start..]]
     end
 
     def first_block(text)
-      (m = text.match(PLANTUML_FIRST_BLOCK_RX)) ? m[1] : text
+      (m = text.match(PLANTUML_BLOCK_RX)) ? m[1] : text
     end
 
     def sub_text(text, sub)
@@ -128,7 +129,7 @@ module AsciidoctorExtensions
     end
 
     def index_text(text, index)
-      blocks = text.scan(PLANTUML_BLOCKS_RX)
+      blocks = text.scan(PLANTUML_BLOCK_RX)
       blocks[index] ? blocks[index][0] : ''
     end
 

--- a/src/main/resources/kroki-antora.rb
+++ b/src/main/resources/kroki-antora.rb
@@ -18,11 +18,12 @@ require 'java'
 # See https://github.com/asciidoctor/asciidoctor-intellij-plugin/issues/516
 
 module AsciidoctorExtensions
-  # Raised when a PlantUML !include points at an Antora resource id that cannot be resolved/read.
-  # It is allowed to escape the defensive rescues below so the diagram fails loudly with a clear
-  # message — matching the Antora build, asciidoctor and standalone PlantUML, which all bail on a
-  # missing include rather than rendering a silently-incomplete diagram.
-  class UnresolvedAntoraInclude < StandardError; end
+  # Raised when a PlantUML !include referencing an Antora resource cannot be safely inlined: the target
+  # can't be resolved/read, an !include_once target repeats, or an include cycle is detected. It is
+  # allowed to escape the defensive rescues below so the diagram fails loudly with a clear message —
+  # matching the asciidoctor-kroki JS extension and the rest of the toolchain (the Antora build,
+  # asciidoctor and standalone PlantUML all bail rather than render a broken diagram).
+  class AntoraIncludeError < StandardError; end
 
   # Antora-aware PlantUML preprocessing helpers.
   module AntoraKroki
@@ -90,10 +91,11 @@ module AsciidoctorExtensions
         # A broken Antora resource id is a real authoring error: fail loudly (like the Antora build,
         # asciidoctor and PlantUML) instead of silently rendering an incomplete diagram. A plain include
         # (no family marker) is not ours to resolve, so it passes through untouched.
-        raise UnresolvedAntoraInclude, "kroki (antora): cannot resolve PlantUML include '#{target}'" if antora_resource_id?(target)
+        raise AntoraIncludeError, "kroki (antora): cannot resolve PlantUML include '#{target}'" if antora_resource_id?(target)
         return original
       end
-      return original if include_stack.include?(resolved) # cycle guard
+      # A cycle would otherwise leave an unresolvable include in the output; fail like the JS extension.
+      raise AntoraIncludeError, "kroki (antora): recursive PlantUML include of '#{target}'" if include_stack.include?(resolved)
 
       raw = ::File.read(resolved, mode: 'rb:utf-8:utf-8')
 
@@ -111,14 +113,16 @@ module AsciidoctorExtensions
         end
 
       if directive == 'include_once'
-        return original if include_once.include?(resolved)
+        # The resource was already inlined; passing the directive through would leave an unresolvable
+        # include for Kroki. Fail like the asciidoctor-kroki JS extension rather than silently skip.
+        raise AntoraIncludeError, "kroki (antora): '#{target}' is included more than once with !include_once" if include_once.include?(resolved)
 
         include_once << resolved
       end
 
       inlined = process_includes(text, include_once, include_stack + [resolved])
       comment.empty? ? inlined : "#{inlined} #{comment}"
-    rescue UnresolvedAntoraInclude
+    rescue AntoraIncludeError
       raise # intentional hard failure: must not be swallowed by the defensive rescue below
     rescue StandardError
       original
@@ -182,7 +186,7 @@ module AsciidoctorExtensions
           if %w[plantuml c4plantuml].include?(diagram_type.to_s)
             begin
               diagram_text = AntoraKroki.preprocess(diagram_text)
-            rescue UnresolvedAntoraInclude
+            rescue AntoraIncludeError
               raise # surface the clear error; don't silently render an incomplete diagram
             rescue StandardError
               # fall back to the unmodified diagram text

--- a/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
+++ b/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
@@ -1,9 +1,12 @@
 package org.asciidoc.intellij;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.PsiTestUtil;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import org.asciidoc.intellij.asciidoc.AntoraReferenceAdapter;
 import org.asciidoc.intellij.editor.AsciiDocHtmlPanel;
@@ -46,6 +49,53 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
     return new File("build/resources/test/testData/psi").getAbsolutePath();
   }
 
+  // Spin up a standalone Asciidoctor runtime with the Kroki Ruby extensions loaded the way the plugin
+  // loads them mid-render, and return its Ruby runtime. The warmup convert initializes the runtime so
+  // the top-level Extensions constant that kroki-extension.rb registers against resolves.
+  private static org.jruby.Ruby loadKrokiExtensions(org.asciidoctor.Asciidoctor adoc) throws IOException {
+    adoc.convert("warmup", org.asciidoctor.Options.builder().safe(SafeMode.UNSAFE).build());
+    org.jruby.Ruby ruby = ((org.asciidoctor.jruby.internal.JRubyAsciidoctor) adoc).getRubyRuntime();
+    ruby.evalScriptlet("require 'asciidoctor/extensions'; "
+      + "Object.const_set(:Extensions, Asciidoctor::Extensions) unless Object.const_defined?(:Extensions)");
+    for (String script : new String[]{"/kroki-extension.rb", "/kroki-antora.rb"}) {
+      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream(script)) {
+        adoc.rubyExtensionRegistry().loadClass(is);
+      }
+    }
+    return ruby;
+  }
+
+  // Replace AntoraKroki.resolve with a stub mapping example$X -> <prefix>X (and nil for anything without
+  // the example$ family marker), so the include preprocessor can be tested independently of real Antora
+  // resolution (covered separately by testShouldResolveAntoraExampleResourceId).
+  private static void stubExampleResolver(org.jruby.Ruby ruby, String prefix) {
+    ruby.evalScriptlet("""
+      module AsciidoctorExtensions
+        module AntoraKroki
+          def self.resolve(t)
+            return nil unless t.is_a?(String) && t.start_with?('example$')
+            '%s' + t.sub('example$', '')
+          end
+        end
+      end
+      """.formatted(prefix));
+  }
+
+  // A Kroki-enabled preview settings instance (default kroki.io server); used by the render-level tests.
+  private static AsciiDocPreviewSettings krokiEnabledSettings() {
+    return new AsciiDocPreviewSettings(
+      SplitFileEditor.SplitEditorLayout.SPLIT,
+      AsciiDocJCEFHtmlPanelProvider.INFO,
+      AsciiDocHtmlPanel.PreviewTheme.INTELLIJ,
+      SafeMode.UNSAFE,
+      new HashMap<>(),
+      true, true, true, "", "",
+      true, true,
+      true,   // enableKroki
+      "",     // krokiUrl -> default https://kroki.io
+      true, true, true, 1, false, "");
+  }
+
   // Regression test for #516: resolveAntoraResourcePath turns an Antora resource id (the form used as a
   // Kroki diagram target and inside PlantUML !include, including the empty-module ":example$..." form)
   // into a local path within the current Antora module. kroki-antora.rb relies on this so that
@@ -82,37 +132,24 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
     assertThat(dir.mkdirs()).isTrue();
     org.asciidoctor.Asciidoctor adoc = org.asciidoctor.Asciidoctor.Factory.create();
     try {
-      Files.writeString(new File(dir, "model.puml").toPath(),
-        "@startuml\n!startsub PART\nclass PartialMarker\n!endsub\nclass Unused\n@enduml\n", UTF_8);
-      Files.writeString(new File(dir, "layout.puml").toPath(),
-        "@startuml\nskinparam backgroundColor LayoutMarker\n@enduml\n", UTF_8);
-      // warm up the Ruby runtime so Asciidoctor's top-level Extensions constant is available when the
-      // kroki extension registers itself (mirrors how the plugin loads it mid-render).
-      adoc.convert("warmup", org.asciidoctor.Options.builder().safe(SafeMode.UNSAFE).build());
-      org.jruby.Ruby ruby = ((org.asciidoctor.jruby.internal.JRubyAsciidoctor) adoc).getRubyRuntime();
-      // kroki-extension.rb registers itself via a top-level `Extensions.register` (= Asciidoctor::Extensions);
-      // make that constant resolvable at top level in this standalone runtime so the script loads.
-      ruby.evalScriptlet("require 'asciidoctor/extensions'; "
-        + "Object.const_set(:Extensions, Asciidoctor::Extensions) unless Object.const_defined?(:Extensions)");
-      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-extension.rb")) {
-        adoc.rubyExtensionRegistry().loadClass(is);
-      }
-      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-antora.rb")) {
-        adoc.rubyExtensionRegistry().loadClass(is);
-      }
-      String base = dir.getPath().replace("\\", "/");
-      String script = ""
-        + "module AsciidoctorExtensions\n"
-        + "  module AntoraKroki\n"
-        + "    def self.resolve(t)\n"
-        + "      return nil unless t.is_a?(String) && t.start_with?('example$')\n"
-        + "      '" + base + "/' + t.sub('example$', '')\n"
-        + "    end\n"
-        + "  end\n"
-        + "end\n"
-        + "AsciidoctorExtensions::AntoraKroki.preprocess("
-        + "\"@startuml\\n!include example$layout.puml\\n!includesub example$model.puml!PART\\nclass MainMarker\\n@enduml\\n\")\n";
-      String out = ruby.evalScriptlet(script).asJavaString();
+      Files.writeString(new File(dir, "model.puml").toPath(), """
+        @startuml
+        !startsub PART
+        class PartialMarker
+        !endsub
+        class Unused
+        @enduml
+        """, UTF_8);
+      Files.writeString(new File(dir, "layout.puml").toPath(), """
+        @startuml
+        skinparam backgroundColor LayoutMarker
+        @enduml
+        """, UTF_8);
+      org.jruby.Ruby ruby = loadKrokiExtensions(adoc);
+      stubExampleResolver(ruby, dir.getPath().replace("\\", "/") + "/");
+      String out = ruby.evalScriptlet("AsciidoctorExtensions::AntoraKroki.preprocess("
+        + "\"@startuml\\n!include example$layout.puml\\n!includesub example$model.puml!PART\\nclass MainMarker\\n@enduml\\n\")")
+        .asJavaString();
 
       assertThat(out)
         .withFailMessage("preprocessed diagram should inline target + includes and drop antora/plantuml syntax: %s", out)
@@ -135,26 +172,9 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
   public void testShouldFailOnUnresolvedAntoraInclude() throws Exception {
     org.asciidoctor.Asciidoctor adoc = org.asciidoctor.Asciidoctor.Factory.create();
     try {
-      adoc.convert("warmup", org.asciidoctor.Options.builder().safe(SafeMode.UNSAFE).build());
-      org.jruby.Ruby ruby = ((org.asciidoctor.jruby.internal.JRubyAsciidoctor) adoc).getRubyRuntime();
-      ruby.evalScriptlet("require 'asciidoctor/extensions'; "
-        + "Object.const_set(:Extensions, Asciidoctor::Extensions) unless Object.const_defined?(:Extensions)");
-      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-extension.rb")) {
-        adoc.rubyExtensionRegistry().loadClass(is);
-      }
-      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-antora.rb")) {
-        adoc.rubyExtensionRegistry().loadClass(is);
-      }
+      org.jruby.Ruby ruby = loadKrokiExtensions(adoc);
       // stub resolver: example$X -> /no/such/dir/X (an unreadable path); anything else -> nil.
-      ruby.evalScriptlet(""
-        + "module AsciidoctorExtensions\n"
-        + "  module AntoraKroki\n"
-        + "    def self.resolve(t)\n"
-        + "      return nil unless t.is_a?(String) && t.start_with?('example$')\n"
-        + "      '/no/such/dir/' + t.sub('example$', '')\n"
-        + "    end\n"
-        + "  end\n"
-        + "end\n");
+      stubExampleResolver(ruby, "/no/such/dir/");
 
       // 1) unresolved example$ include -> preprocess raises a named error carrying the resource id
       String raised = ruby.evalScriptlet(""
@@ -179,6 +199,44 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
         .contains("class X");
     } finally {
       adoc.shutdown();
+    }
+  }
+
+  // End-to-end: with Kroki enabled, a plantuml:: block macro whose target is an Antora example$ resource
+  // (which itself !includes another example$ resource) resolves + inlines through the full render pipeline
+  // and yields a Kroki image URL. Exercises the integration the preprocess/resolver unit tests don't.
+  // The fixture lives on the real filesystem (Kroki reads diagram files via java.io, which can't see the
+  // in-memory test VFS) and is registered as a project content root so its antora.yml gets indexed
+  // (Antora resolution looks modules up via the project index).
+  public void testShouldRenderAntoraExampleDiagramViaKroki() throws Exception {
+    File base = new File(System.getProperty("java.io.tmpdir"), "krokiE2E-" + System.nanoTime());
+    File examples = new File(base, "modules/ROOT/examples");
+    File pages = new File(base, "modules/ROOT/pages");
+    assertThat(examples.mkdirs()).isTrue();
+    assertThat(pages.mkdirs()).isTrue();
+    Files.writeString(new File(base, "antora.yml").toPath(), "name: e2e\nversion: ~\n", UTF_8);
+    Files.writeString(new File(examples, "layout.puml").toPath(),
+      "@startuml\nhide circle\nskinparam backgroundColor #EEEBDC\n@enduml\n", UTF_8);
+    Files.writeString(new File(examples, "model.puml").toPath(),
+      "@startuml\n!include example$layout.puml\nclass FromExampleInclude\n@enduml\n", UTF_8);
+    VirtualFile baseVf = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(base);
+    assertThat(baseVf).isNotNull();
+    VfsUtil.markDirtyAndRefresh(false, true, true, baseVf);
+    Module module = myFixture.getModule();
+    PsiTestUtil.addContentRoot(module, baseVf);
+    AsciiDocApplicationSettings.getInstance().setAsciiDocPreviewSettings(krokiEnabledSettings());
+    try {
+      VirtualFile pagesVf = LocalFileSystem.getInstance().findFileByIoFile(pages);
+      assertThat(pagesVf).isNotNull();
+      AsciiDocWrapper wrapper = new AsciiDocWrapper(getProject(), pagesVf, null, "diagram.adoc");
+      String html = wrapper.render("plantuml::example$model.puml[]\n", Collections.emptyList());
+      assertThat(html)
+        .withFailMessage("expected a Kroki PlantUML image (example$ target + nested example$ include resolved end-to-end): %s", html)
+        .contains("https://kroki.io/plantuml/");
+    } finally {
+      AsciiDocApplicationSettings.getInstance().setAsciiDocPreviewSettings(AsciiDocPreviewSettings.DEFAULT);
+      PsiTestUtil.removeContentEntry(module, baseVf);
+      FileUtil.delete(base);
     }
   }
 

--- a/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
+++ b/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
@@ -129,6 +129,59 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
     }
   }
 
+  // A broken Antora include is a hard error (matching the Antora build, asciidoctor and PlantUML):
+  // preprocess raises a clear, named exception instead of silently rendering an incomplete diagram.
+  // A plain (non-resource) include has no family marker and must pass through untouched.
+  public void testShouldFailOnUnresolvedAntoraInclude() throws Exception {
+    org.asciidoctor.Asciidoctor adoc = org.asciidoctor.Asciidoctor.Factory.create();
+    try {
+      adoc.convert("warmup", org.asciidoctor.Options.builder().safe(SafeMode.UNSAFE).build());
+      org.jruby.Ruby ruby = ((org.asciidoctor.jruby.internal.JRubyAsciidoctor) adoc).getRubyRuntime();
+      ruby.evalScriptlet("require 'asciidoctor/extensions'; "
+        + "Object.const_set(:Extensions, Asciidoctor::Extensions) unless Object.const_defined?(:Extensions)");
+      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-extension.rb")) {
+        adoc.rubyExtensionRegistry().loadClass(is);
+      }
+      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-antora.rb")) {
+        adoc.rubyExtensionRegistry().loadClass(is);
+      }
+      // stub resolver: example$X -> /no/such/dir/X (an unreadable path); anything else -> nil.
+      ruby.evalScriptlet(""
+        + "module AsciidoctorExtensions\n"
+        + "  module AntoraKroki\n"
+        + "    def self.resolve(t)\n"
+        + "      return nil unless t.is_a?(String) && t.start_with?('example$')\n"
+        + "      '/no/such/dir/' + t.sub('example$', '')\n"
+        + "    end\n"
+        + "  end\n"
+        + "end\n");
+
+      // 1) unresolved example$ include -> preprocess raises a named error carrying the resource id
+      String raised = ruby.evalScriptlet(""
+        + "begin\n"
+        + "  AsciidoctorExtensions::AntoraKroki.preprocess("
+        + "\"@startuml\\n!include example$layout/missing.puml\\nclass MainMarker\\n@enduml\\n\")\n"
+        + "  'NO_ERROR'\n"
+        + "rescue => e\n"
+        + "  e.class.name + '|' + e.message\n"
+        + "end\n").asJavaString();
+      assertThat(raised)
+        .withFailMessage("expected a hard failure naming the unresolved include, got: %s", raised)
+        .contains("UnresolvedAntoraInclude")
+        .contains("example$layout/missing.puml");
+
+      // 2) a plain relative include (no family marker) is not ours to resolve -> passes through untouched
+      String out = ruby.evalScriptlet("AsciidoctorExtensions::AntoraKroki.preprocess("
+        + "\"@startuml\\n!include plain.puml\\nclass X\\n@enduml\\n\")").asJavaString();
+      assertThat(out)
+        .withFailMessage("plain relative include should pass through untouched: %s", out)
+        .contains("!include plain.puml")
+        .contains("class X");
+    } finally {
+      adoc.shutdown();
+    }
+  }
+
   public void testShouldRenderPlainAsciidoc() {
     String html = asciidocWrapper.render("this is *bold*.", Collections.emptyList());
     assertThat(html).withFailMessage("should contain formatted output").contains("<strong>bold</strong>");

--- a/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
+++ b/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
@@ -1,8 +1,11 @@
 package org.asciidoc.intellij;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.asciidoc.intellij.asciidoc.AntoraReferenceAdapter;
 import org.asciidoc.intellij.editor.AsciiDocHtmlPanel;
 import org.asciidoc.intellij.editor.jcef.AsciiDocJCEFHtmlPanelProvider;
 import org.asciidoc.intellij.settings.AsciiDocApplicationSettings;
@@ -14,6 +17,7 @@ import org.junit.Assert;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Writer;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -35,6 +39,94 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
   public void setUp() throws Exception {
     super.setUp();
     asciidocWrapper = new AsciiDocWrapper(getProject(), LocalFileSystem.getInstance().findFileByIoFile(new File(System.getProperty("java.io.tmpdir"))), null, "test");
+  }
+
+  @Override
+  protected String getTestDataPath() {
+    return new File("build/resources/test/testData/psi").getAbsolutePath();
+  }
+
+  // Regression test for #516: resolveAntoraResourcePath turns an Antora resource id (the form used as a
+  // Kroki diagram target and inside PlantUML !include, including the empty-module ":example$..." form)
+  // into a local path within the current Antora module. kroki-antora.rb relies on this so that
+  // plantuml::example$...[] and !include example$... resolve in the preview. Reuses the antoraModule
+  // fixture that the resolution tests in AsciiDocPsiTest also use.
+  public void testShouldResolveAntoraExampleResourceId() {
+    VirtualFile root = myFixture.copyDirectoryToProject("antoraModule", "antoraModule");
+    VirtualFile moduleDir = root.findFileByRelativePath("componentV1/modules/ROOT");
+    assertThat(moduleDir).isNotNull();
+    AntoraReferenceAdapter.setAntoraDetails(getProject(), moduleDir, new File(moduleDir.getPath() + "/pages"), "test.adoc");
+    try {
+      String resolved = AntoraReferenceAdapter.resolveAntoraResourcePath("example$example.txt");
+      assertThat(resolved).withFailMessage("example$ id should resolve to a local path").isNotNull();
+      assertThat(resolved.replace('\\', '/')).endsWith("componentV1/modules/ROOT/examples/example.txt");
+
+      // Antora may present a family-only id in its empty-module form ":example$..."
+      assertThat(AntoraReferenceAdapter.resolveAntoraResourcePath(":example$example.txt")).isEqualTo(resolved);
+
+      // not an Antora resource id (no family prefix) / a URL -> null, so the caller keeps the original target
+      assertThat(AntoraReferenceAdapter.resolveAntoraResourcePath("example.txt")).isNull();
+      assertThat(AntoraReferenceAdapter.resolveAntoraResourcePath("https://example.com/example.txt")).isNull();
+    } finally {
+      AntoraReferenceAdapter.setAntoraDetails(null, null, null, null);
+    }
+  }
+
+  // Regression test for #516 (Part 2): the PlantUML include preprocessor in kroki-antora.rb must inline
+  // !include / !includesub directives that point at Antora resources (resolved to local files) before
+  // the diagram is handed to Kroki, and strip the @startuml/@enduml tags. We drive the real Ruby code
+  // (kroki-extension.rb + kroki-antora.rb) with a stubbed resolver so the test is independent of Antora
+  // module resolution (which is covered separately by testShouldResolveAntoraExampleResourceId).
+  public void testShouldInlineAntoraResourceIncludesInPlantUml() throws Exception {
+    File dir = new File(System.getProperty("java.io.tmpdir"), "krokiPreprocess-" + System.nanoTime());
+    assertThat(dir.mkdirs()).isTrue();
+    org.asciidoctor.Asciidoctor adoc = org.asciidoctor.Asciidoctor.Factory.create();
+    try {
+      Files.writeString(new File(dir, "model.puml").toPath(),
+        "@startuml\n!startsub PART\nclass PartialMarker\n!endsub\nclass Unused\n@enduml\n", UTF_8);
+      Files.writeString(new File(dir, "layout.puml").toPath(),
+        "@startuml\nskinparam backgroundColor LayoutMarker\n@enduml\n", UTF_8);
+      // warm up the Ruby runtime so Asciidoctor's top-level Extensions constant is available when the
+      // kroki extension registers itself (mirrors how the plugin loads it mid-render).
+      adoc.convert("warmup", org.asciidoctor.Options.builder().safe(SafeMode.UNSAFE).build());
+      org.jruby.Ruby ruby = ((org.asciidoctor.jruby.internal.JRubyAsciidoctor) adoc).getRubyRuntime();
+      // kroki-extension.rb registers itself via a top-level `Extensions.register` (= Asciidoctor::Extensions);
+      // make that constant resolvable at top level in this standalone runtime so the script loads.
+      ruby.evalScriptlet("require 'asciidoctor/extensions'; "
+        + "Object.const_set(:Extensions, Asciidoctor::Extensions) unless Object.const_defined?(:Extensions)");
+      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-extension.rb")) {
+        adoc.rubyExtensionRegistry().loadClass(is);
+      }
+      try (InputStream is = AsciiDocWrapper.class.getResourceAsStream("/kroki-antora.rb")) {
+        adoc.rubyExtensionRegistry().loadClass(is);
+      }
+      String base = dir.getPath().replace("\\", "/");
+      String script = ""
+        + "module AsciidoctorExtensions\n"
+        + "  module AntoraKroki\n"
+        + "    def self.resolve(t)\n"
+        + "      return nil unless t.is_a?(String) && t.start_with?('example$')\n"
+        + "      '" + base + "/' + t.sub('example$', '')\n"
+        + "    end\n"
+        + "  end\n"
+        + "end\n"
+        + "AsciidoctorExtensions::AntoraKroki.preprocess("
+        + "\"@startuml\\n!include example$layout.puml\\n!includesub example$model.puml!PART\\nclass MainMarker\\n@enduml\\n\")\n";
+      String out = ruby.evalScriptlet(script).asJavaString();
+
+      assertThat(out)
+        .withFailMessage("preprocessed diagram should inline target + includes and drop antora/plantuml syntax: %s", out)
+        .contains("MainMarker")          // the diagram's own content is kept
+        .contains("LayoutMarker")        // plain !include example$ inlined (first @startuml block)
+        .contains("PartialMarker")       // !includesub example$...!PART inlined (the named sub only)
+        .doesNotContain("Unused")        // content outside the !startsub/!endsub region is not included
+        .doesNotContain("example$")
+        .doesNotContain("!include")
+        .doesNotContain("@startuml");
+    } finally {
+      adoc.shutdown();
+      FileUtil.delete(dir);
+    }
   }
 
   public void testShouldRenderPlainAsciidoc() {

--- a/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
+++ b/src/test/java/org/asciidoc/intellij/AsciiDocWrapperTest.java
@@ -187,7 +187,7 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
         + "end\n").asJavaString();
       assertThat(raised)
         .withFailMessage("expected a hard failure naming the unresolved include, got: %s", raised)
-        .contains("UnresolvedAntoraInclude")
+        .contains("AntoraIncludeError")
         .contains("example$layout/missing.puml");
 
       // 2) a plain relative include (no family marker) is not ours to resolve -> passes through untouched
@@ -199,6 +199,34 @@ public class AsciiDocWrapperTest extends BasePlatformTestCase {
         .contains("class X");
     } finally {
       adoc.shutdown();
+    }
+  }
+
+  // Repeating !include_once for the same Antora resource must fail fast (matching the asciidoctor-kroki
+  // JS extension), not leave an unresolvable directive in the diagram sent to Kroki (PR #2054 review).
+  public void testShouldFailOnRepeatedIncludeOnce() throws Exception {
+    File dir = new File(System.getProperty("java.io.tmpdir"), "krokiIncludeOnce-" + System.nanoTime());
+    assertThat(dir.mkdirs()).isTrue();
+    org.asciidoctor.Asciidoctor adoc = org.asciidoctor.Asciidoctor.Factory.create();
+    try {
+      Files.writeString(new File(dir, "shared.puml").toPath(), "@startuml\nclass Shared\n@enduml\n", UTF_8);
+      org.jruby.Ruby ruby = loadKrokiExtensions(adoc);
+      stubExampleResolver(ruby, dir.getPath().replace("\\", "/") + "/");
+      String raised = ruby.evalScriptlet(""
+        + "begin\n"
+        + "  AsciidoctorExtensions::AntoraKroki.preprocess("
+        + "\"@startuml\\n!include_once example$shared.puml\\n!include_once example$shared.puml\\nclass Main\\n@enduml\\n\")\n"
+        + "  'NO_ERROR'\n"
+        + "rescue => e\n"
+        + "  e.class.name + '|' + e.message\n"
+        + "end\n").asJavaString();
+      assertThat(raised)
+        .withFailMessage("a repeated !include_once should fail fast, got: %s", raised)
+        .contains("AntoraIncludeError")
+        .contains("!include_once");
+    } finally {
+      adoc.shutdown();
+      FileUtil.delete(dir);
     }
   }
 


### PR DESCRIPTION
### Resolve Antora example$ resource ids in the Kroki PlantUML integration (#516)

I have migrated a quite large documentation site with numerous PlantUML diagrams from plain asciidoc to antora. The PlantUML diagrams themself are using `!includes`  to reference styling and other shared uml. I created a self-contained [demo/example](https://github.com/cachescrubber/antora-kroki-example) project show casing my setup. The demo project generates fine with the antora+asciidoctor-kroki extension. Local IDE preview using this plugin fails, because the ruby implementation here differs from the js version used by antora. This pr aims to get on par with the asciidoctor-kroki js extension.

Disclaimer: All code changes are made by Claude, all commit messages clearly state this using Co-Authored-By. Hope that is ok.

## What kind of change does this PR introduce?
- [ ] Bugfix
- [ x] Feature
- [ ] Documentation
- [ ] Other, please describe:

## Does this PR introduce a breaking change?
- [x ] No
- [ ] Yes

## Checklist:
<!-- Go over all the following points, and place an `x` in all the boxes that apply. -->
- [ x] I have updated the [documentation](https://github.com/asciidoctor/asciidoctor-intellij-plugin/blob/main/doc/users-guide/modules/ROOT/pages/features/) to reflect the changes introduced by this PR.

## References

- Closes #516
- Refs #489
- Mirrors the asciidoctor-kroki JS extension's PlantUML include preprocessing:
  https://github.com/asciidoctor/asciidoctor-kroki/blob/master/src/preprocess.js
  (`preprocessPlantUML` → `preprocessPlantUmlIncludes`)
