### PR TITLE
Declare dependency on JCEF module for 2026.2

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,7 +9,7 @@ This document provides a high-level view of the changes introduced by release.
 
 === 0.45.6
 
-...
+- Declare dependency on the JCEF module so the plugin loads on 2026.2 where JCEF became a separate plugin (#2073)
 
 === 0.45.5
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -15,6 +15,8 @@
   <idea-version since-build="253.25908"/> <!-- 2025.1 EAP, also change build.gradle.kts -->
   <!-- please see https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html -->
   <depends>com.intellij.modules.lang</depends>
+  <!-- JCEF is a module alias of the core IDE up to 2026.1, and a separate plugin starting with 2026.2 (#2073) -->
+  <depends>com.intellij.modules.jcef</depends>
   <depends optional="true" config-file="org.asciidoctor.intellij.asciidoc-intellilang.xml">org.intellij.intelliLang</depends>
   <depends optional="true" config-file="org.asciidoctor.intellij.asciidoc-java.xml">com.intellij.modules.java</depends>
   <depends optional="true" config-file="org.asciidoctor.intellij.asciidoc-json.xml">com.intellij.modules.json</depends>


### PR DESCRIPTION
## What kind of change does this PR introduce?
- [x] Bugfix

## Does this PR introduce a breaking change?
- [x] No

## Description

IntelliJ 2026.2 (build 262.8665) extracted JCEF from the core platform into a separate plugin with the id `com.intellij.modules.jcef`. Without declaring this dependency, the plugin classloader no longer resolves `com.intellij.ui.jcef.JBCefApp`, and the resulting `NoClassDefFoundError` prevents AsciiDoc files from opening at all (no editor tab appears).

In earlier versions (down to the supported 2025.3 baseline), the same id exists as a module alias of the core IDE — verified in the 2025.3.1 distribution — so this dependency is backward compatible across the whole supported range. JetBrains' bundled Markdown plugin declares the same dependency for its JCEF preview.

Verified locally: `verifyPluginProjectConfiguration`, `verifyPluginStructure`, and `buildPlugin` pass, and the built zip loads the descriptor with the new `<depends>` entry.

Fixes #2073

## Checklist:
- [ ] Documentation update — not needed, no user-facing feature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)